### PR TITLE
Change "i18n Core" to "i18n"

### DIFF
--- a/index.html
+++ b/index.html
@@ -41,7 +41,7 @@
                 {   name:       "<span lang='ja'>塩澤 元</span> (Hajime Shiozawa), (<span lang='ja'>第２版</span> 2nd edition)",
                     company:    "Invited Expert" },
           ],
-		wg:           "Internationalization Core Working Group",
+		wg:           "Internationalization Working Group",
 		wgURI:        "https://www.w3.org/International/core/",
 		bugTracker: { new: "https://github.com/w3c/jlreq/issues", open: "https://github.com/w3c/jlreq/issues" } ,
 		wgPublicList: "public-i18n-cjk",

--- a/ja/index.html
+++ b/ja/index.html
@@ -42,7 +42,7 @@
                 {   name:       "塩澤 元 (Hajime Shiozawa), (第２版)",
                     company:    "Invited Expert" },
           ],
-		wg:           "Internationalization Core Working Group",
+		wg:           "Internationalization Working Group",
 		wgURI:        "https://www.w3.org/International/core/",
 		bugTracker: { new: "https://github.com/w3c/jlreq/issues", open: "https://github.com/w3c/jlreq/issues" } ,
 		wgPublicList: "public-i18n-cjk",

--- a/temporary_bilingual_devt/index.html
+++ b/temporary_bilingual_devt/index.html
@@ -42,7 +42,7 @@
                 {   name:       "<span lang='ja'>塩澤 元</span> (Hajime Shiozawa), (<span lang='ja'>第２版</span> 2nd edition)",
                     company:    "Invited Expert" },
           ],
-		wg:           "Internationalization Core Working Group",
+		wg:           "Internationalization Working Group",
 		wgURI:        "https://www.w3.org/International/core/",
 		//wgPublicList: "public-i18n-cjk",
         wgPatentURI:  "https://www.w3.org/2004/01/pp-impl/32113/status",


### PR DESCRIPTION
Since we don't use the name "i18n Core" any more.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/jlreq/pull/29.html" title="Last updated on May 6, 2019, 1:14 AM UTC (001831b)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/jlreq/29/fe92d65...001831b.html" title="Last updated on May 6, 2019, 1:14 AM UTC (001831b)">Diff</a>