### PR TITLE
Fixed wrong description in section 3.3.8 note 3

### DIFF
--- a/index.html
+++ b/index.html
@@ -4128,7 +4128,7 @@
         <p its-locale-filter-list="ja" lang="ja">JIS X 4051では，片仮名は漢字と同じ文字クラスに含まれている．したがって，片仮名についてはルビ文字を掛けることは禁止されている．</p>
       </aside>
       <aside class="note" id="n128">
-        <p its-locale-filter-list="en" lang="en"> There is another variation that allows ruby text to overhang any <a class="characterClass" href="#cl-19">ideographic characters (cl-19)</a>, <a class="characterClass" href="#cl-15">hiragana (cl-15)</a> or <a class="characterClass" href="#cl-16">katakana (cl-16)</a> up to the full-width
+        <p its-locale-filter-list="en" lang="en"> There is another variation that allows ruby text to overhang any <a class="characterClass" href="#cl-19">ideographic characters (cl-19)</a>, <a class="characterClass" href="#cl-15">hiragana (cl-15)</a> or <a class="characterClass" href="#cl-16">katakana (cl-16)</a> up to the half-width
           size of a ruby character (see [[[#fig2_3_32]]]). </p>
         <p its-locale-filter-list="ja" lang="ja">ルビが付いた親文字群の前又は後ろの文字が，<a class="characterClass" href="#cl-19">漢字等（cl-19）</a>，<a class="characterClass" href="#cl-15">平仮名（cl-15）</a>又は<a class="characterClass" href="#cl-16">片仮名（cl-16）</a>のいずれでも，最大でルビ文字サイズの二分まで<a href="#term.ruby" class="termref2nd">ルビ</a>文字を掛けてもよい，とする処理法もある（[[[#fig2_3_32]]]）．</p>
       </aside>


### PR DESCRIPTION
Fixed text from full-width to half-width in section 3.3.8 note 3
Fix for #33 

-@himorin


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/himorin/jlreq/pull/47.html" title="Last updated on May 13, 2019, 8:04 AM UTC (6652d52)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/jlreq/47/97e0082...himorin:6652d52.html" title="Last updated on May 13, 2019, 8:04 AM UTC (6652d52)">Diff</a>