### PR TITLE
fixed typo in figure caption of figure 177 in section 3.7.4

### DIFF
--- a/index.html
+++ b/index.html
@@ -5100,10 +5100,10 @@
           </aside>
           <figure id="fig2_7_62"> 
       <img its-locale-filter-list="en" src="images/img2_7_62.png" alt="Example of math symbols and math operators set within an ordinary line." width="469" height="446">
-      <img its-locale-filter-list="ja" lang="ja" src="images_ja/img2_7_62.png" alt="漢字等，平仮名及び片仮名の前後に統合類又は演算記号を配置した例" width="469" height="407">
+      <img its-locale-filter-list="ja" lang="ja" src="images_ja/img2_7_62.png" alt="漢字等，平仮名及び片仮名の前後に等号類又は演算記号を配置した例" width="469" height="407">
             <figcaption>
         <span its-locale-filter-list="en" lang="en">Example of math symbols and math operators set within an ordinary line.</span>
-        <span its-locale-filter-list="ja" lang="ja">漢字等，平仮名及び片仮名の前後に統合類又は演算記号を配置した例</span>
+        <span its-locale-filter-list="ja" lang="ja">漢字等，平仮名及び片仮名の前後に等号類又は演算記号を配置した例</span>
         </figcaption>
 
           </figure>


### PR DESCRIPTION
from PR #13 , fixed typo in Japanese figure caption of figure 177 in section 3.7.4

+@mashabow
-@himorin


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/himorin/jlreq/pull/51.html" title="Last updated on May 13, 2019, 8:44 AM UTC (5a848a1)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/jlreq/51/4187d27...himorin:5a848a1.html" title="Last updated on May 13, 2019, 8:44 AM UTC (5a848a1)">Diff</a>