### PR TITLE
fix English in fix for Missing condition in section 3.3.8, first "f." #15

### DIFF
--- a/index.html
+++ b/index.html
@@ -4040,8 +4040,8 @@
       </figure>
       <p its-locale-filter-list="en" lang="en"> When the length of the ruby text is longer than that of the base characters, the method of composing the main text depends on how
         much the ruby text hangs over the <a class="characterClass" href="#cl-19">ideographic character (cl-19)</a>, <a class="characterClass" href="#cl-15">hiragana (cl-15)</a> or <a href="#term.punctuation-marks" class="termref">punctuation marks</a>, which are  attached to the base
-        characters. The following are the general rules (see [[[#fig2_3_30]]] and [[[#fig2_3_31]]]). They were established especially in order to avoid misreading and to maintain the beauty of the layout.
-        Noted that the detailed value of spaces between characters for cases of ruby letters hanging over the base characters is described in [[[#spacing_between_characters]]] as Table 1 in accordance with [[[#about_character_classes]]]. </p>
+        characters. The following are the general rules (see [[[#fig2_3_30]]] and [[[#fig2_3_31]]]). They were established especially in order to avoid misreading, and to maintain the beauty of, the layout.
+        Note that the detailed values for inter-character spacing for cases of ruby characters hanging over the base characters is described in [[[#spacing_between_characters]]] as Table 1 in accordance with [[[#about_character_classes]]]. </p>
       <p its-locale-filter-list="ja" lang="ja">ルビ文字の文字列が親文字の文字列より長い場合は，親文字の前後に配置する他の<a class="characterClass" href="#cl-19">漢字等（cl-19）</a>，<a class="characterClass" href="#cl-15">平仮名（cl-15）</a>や<a href="#term.punctuation-marks" class="termref">約物</a>などにどこまで親文字よりはみ出したルビ文字が掛かってよいかが問題となる．一般に次のように処理している（[[[#fig2_3_30]]]，[[[#fig2_3_31]]]）．これはもっぱら誤読を避けること，及び体裁を考慮しての処理である．なお，ルビ文字の文字列が親文字の文字列よりはみ出した場合についての詳細は，[[[#about_character_classes]]]で説明する文字クラスに従い，表の形式にして<a href="#spacing_between_characters">附属書 B 文字間の空き量</a>で示す．</p>
       <figure id="fig2_3_30"> 
       <img its-locale-filter-list="en" src="images/img2_3_30.png" alt="Example 1 of distribution of ruby characters overhanging adjacent characters." width="201" height="684">

--- a/index.html
+++ b/index.html
@@ -1450,9 +1450,9 @@
       <p its-locale-filter-list="ja" lang="ja">ただし，<span class="index" id="d3e6991">行の配置位置</span>については，次のような例外がある．</p>
       <ol>
         <li id="id91">
-          <p its-locale-filter-list="en" lang="en">When inserting more than one illustration or table item in horizontal writing mode, assuming that there is no text to the left or right of the items, the items may either slip off the lines established for the kihon-hanmen (see [[[#fig_ad1_10]]]), or stick to the lines (see [[[#fig_ad1_11]]]). The former approach is used,
+          <p its-locale-filter-list="en" lang="en">When inserting more than one illustration or table item in horizontal writing mode, assuming that there is no text to the left or right of the items, the items may either slip off the grid established for the kihon-hanmen (see [[[#fig_ad1_10]]]), or stick to the grid (see [[[#fig_ad1_11]]]). The former approach is used,
             whenever possible,
-            to achieve inter-character spacing before and after illustrations or tables constant. (This method is often used in books.) (This processing method is defined in JIS X 4051, sec. 10.3.2., d.)</p>
+            to achieve an equal amount of space before and after illustrations or tables. (This method is often used in books.) (This processing method is defined in JIS X 4051, sec. 10.3.2., d.)</p>
           <p its-locale-filter-list="ja" lang="ja">横組で，図版や表の左右にテキストを配置しない方法とした場合，1ページに2つ以上の<span class="index" id="d3e7007"></span>や表が挿入されたときは，基本版面で設定した行の位置からずれることがある（[[[#fig_ad1_10]]]）．ただし，基本版面で設定した行の位置に配置する方法もある（[[[#fig_ad1_11]]]）．前者の方法は，図版や表の前後の空き量をできるだけ均一にするという考え方による（この方法を採用している書籍が多い）．この処理方法については，JIS X 4051の10.3.2のd）に規定がある．</p>
           <figure id="fig_ad1_10"> 
       <img its-locale-filter-list="en" src="images/img_ad1_10.png" alt="Positioning of lines with multiple illustrations - 1." width="557" height="494">


### PR DESCRIPTION
tweak description of ruby spacing


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/jlreq/pull/68.html" title="Last updated on Jun 17, 2019, 7:44 PM UTC (b954d4a)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/jlreq/68/8791dbb...b954d4a.html" title="Last updated on Jun 17, 2019, 7:44 PM UTC (b954d4a)">Diff</a>