### PR TITLE
3.3.8 second paragraph: Fix English for inter-character spacing of ruby #80

### DIFF
--- a/index.html
+++ b/index.html
@@ -4040,7 +4040,7 @@
       </figure>
       <p its-locale-filter-list="en" lang="en"> When the length of the ruby text is longer than that of the base characters, the method of composing the main text depends on how
         much the ruby text hangs over the <a class="characterClass" href="#cl-19">ideographic character (cl-19)</a>, <a class="characterClass" href="#cl-15">hiragana (cl-15)</a> or <a href="#term.punctuation-marks" class="termref">punctuation marks</a>, which are  attached to the base
-        characters. The following are the general rules (see [[[#fig2_3_30]]] and [[[#fig2_3_31]]]). They were established especially in order to avoid misreading, and to maintain the beauty of, the layout.
+        characters. The following are the general rules (see [[[#fig2_3_30]]] and [[[#fig2_3_31]]]). They were established especially in order to avoid misreading the base text, as well as to maintain the beauty of the layout.
         Note that the detailed values for inter-character spacing for cases of ruby characters hanging over the base characters is described in [[[#spacing_between_characters]]] as Table 1 in accordance with [[[#about_character_classes]]]. </p>
       <p its-locale-filter-list="ja" lang="ja">ルビ文字の文字列が親文字の文字列より長い場合は，親文字の前後に配置する他の<a class="characterClass" href="#cl-19">漢字等（cl-19）</a>，<a class="characterClass" href="#cl-15">平仮名（cl-15）</a>や<a href="#term.punctuation-marks" class="termref">約物</a>などにどこまで親文字よりはみ出したルビ文字が掛かってよいかが問題となる．一般に次のように処理している（[[[#fig2_3_30]]]，[[[#fig2_3_31]]]）．これはもっぱら誤読を避けること，及び体裁を考慮しての処理である．なお，ルビ文字の文字列が親文字の文字列よりはみ出した場合についての詳細は，[[[#about_character_classes]]]で説明する文字クラスに従い，表の形式にして<a href="#spacing_between_characters">附属書 B 文字間の空き量</a>で示す．</p>
       <figure id="fig2_3_30"> 

--- a/index.html
+++ b/index.html
@@ -4040,8 +4040,8 @@
       </figure>
       <p its-locale-filter-list="en" lang="en"> When the length of the ruby text is longer than that of the base characters, the method of composing the main text depends on how
         much the ruby text hangs over the <a class="characterClass" href="#cl-19">ideographic character (cl-19)</a>, <a class="characterClass" href="#cl-15">hiragana (cl-15)</a> or <a href="#term.punctuation-marks" class="termref">punctuation marks</a>, which are  attached to the base
-        characters. The following are the general rules (see [[[#fig2_3_30]]] and [[[#fig2_3_31]]]). They were established especially in order to avoid misreading and to maintain the beauty of the layout.
-        Noted that the detailed value of spaces between characters for cases of ruby letters hanging over the base characters is described in [[[#spacing_between_characters]]] as Table 1 in accordance with [[[#about_character_classes]]]. </p>
+        characters. The following are the general rules (see [[[#fig2_3_30]]] and [[[#fig2_3_31]]]). They were established especially in order to avoid misreading, and to maintain the beauty of, the layout.
+        Note that the detailed values for inter-character spacing for cases of ruby characters hanging over the base characters is described in [[[#spacing_between_characters]]] as Table 1 in accordance with [[[#about_character_classes]]]. </p>
       <p its-locale-filter-list="ja" lang="ja">ルビ文字の文字列が親文字の文字列より長い場合は，親文字の前後に配置する他の<a class="characterClass" href="#cl-19">漢字等（cl-19）</a>，<a class="characterClass" href="#cl-15">平仮名（cl-15）</a>や<a href="#term.punctuation-marks" class="termref">約物</a>などにどこまで親文字よりはみ出したルビ文字が掛かってよいかが問題となる．一般に次のように処理している（[[[#fig2_3_30]]]，[[[#fig2_3_31]]]）．これはもっぱら誤読を避けること，及び体裁を考慮しての処理である．なお，ルビ文字の文字列が親文字の文字列よりはみ出した場合についての詳細は，[[[#about_character_classes]]]で説明する文字クラスに従い，表の形式にして<a href="#spacing_between_characters">附属書 B 文字間の空き量</a>で示す．</p>
       <figure id="fig2_3_30"> 
       <img its-locale-filter-list="en" src="images/img2_3_30.png" alt="Example 1 of distribution of ruby characters overhanging adjacent characters." width="201" height="684">


### PR DESCRIPTION
(edit by @himorin to add reference link, this is for #80 )


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/jlreq/pull/81.html" title="Last updated on Jun 20, 2019, 5:11 PM UTC (94590cb)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/jlreq/81/8da8f10...94590cb.html" title="Last updated on Jun 20, 2019, 5:11 PM UTC (94590cb)">Diff</a>