### PR TITLE
Fix an id in the English glossary

### DIFF
--- a/index.html
+++ b/index.html
@@ -22953,7 +22953,7 @@
           <div>b) To number the pages continuously across those of all books, such as a series published in separate volumes. Also to number the pages continuously across those of all issues of a periodical published in a year, aside from pagination per issue.</div>
           <div>(JIS Z 8125)</div></td>
       </tr>
-      <tr id="term.drop-heading">
+      <tr id="term.cut-in-heading">
         <td>cut-in heading</td>
         <td>窓見出し</td>
         <td>madomidashi</td>


### PR DESCRIPTION
The ID in the Japanese glossary is `ja-term.cut-in-heading`.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***

### :boom: Error: socket hang up :boom: ###

[PR Preview](https://github.com/tobie/pr-preview#pr-preview) failed to build. _(Last tried on Jun 20, 2019, 12:07 PM UTC)_.

<details>
<summary>More</summary>


PR Preview relies on a number of web services to run. There seems to be an issue with the following one:

:rotating_light: [Spec Generator](https://www.w3.org/2015/labs/) - Spec Generator is the web service used to build specs that rely on ReSpec.

:link: [Related URL](https://labs.w3.org/spec-generator/?type=respec&url=https%3A%2F%2Frawcdn.githack.com%2Fw3c%2Fjlreq%2F1b85b171797f1f1ed050c9087c75683d98af0ebb%2Findex.html%3FisPreview%3Dtrue)



_If you don't have enough information above to solve the error by yourself (or to understand to which web service the error is related to, if any), please [file an issue](https://github.com/tobie/pr-preview/issues/new?title=Error%20not%20surfaced%20properly&body=See%20w3c/jlreq%2387.)._
</details>
