### PR TITLE
Merge English and Japanese glossaries into one

### DIFF
--- a/index.html
+++ b/index.html
@@ -22748,307 +22748,307 @@
       </thead>
       <tbody>
         <tr id="term.back-matter">
-          <td class="xfq-term">back matter</td>
-          <td class="xfq-ja">後付</td>
-          <td class="xfq-transliteration">atozuke<br/>あとづけ</td>
-          <td class="xfq-def">
+          <td>back matter</td>
+          <td>後付</td>
+          <td>atozuke<br/>あとづけ</td>
+          <td>
             <p its-locale-filter-list="en" lang="en">Appendices, supplements, glossary of terms, index and/or bibliography,  and so on, appended at the end of a book.</p>
             <p its-locale-filter-list="ja" lang="ja">書籍の巻末に付けられる付録，補遺，語彙解説，索引，文献など．</p>
           </td>
         </tr>
         <tr id="term.base-characters">
-          <td class="xfq-term">base character</td>
-          <td class="xfq-ja">親文字</td>
-          <td class="xfq-transliteration">oya moji<br/>おやもじ</td>
-          <td class="xfq-def">
+          <td>base character</td>
+          <td>親文字</td>
+          <td>oya moji<br/>おやもじ</td>
+          <td>
             <p its-locale-filter-list="en" lang="en">A character to be annotated by ruby, ornament characters, or emphasis dots.</p>
             <p its-locale-filter-list="ja" lang="ja">ルビ，添え字又は圏点が付けられたとき，その対象となる文字．</p>
           </td>
         </tr>
         <tr id="term.base-line">
-          <td class="xfq-term">base line</td>
-          <td class="xfq-ja">並び線</td>
-          <td class="xfq-transliteration">narabi sen<br/>ならびせん</td>
-          <td class="xfq-def">
+          <td>base line</td>
+          <td>並び線</td>
+          <td>narabi sen<br/>ならびせん</td>
+          <td>
             <p its-locale-filter-list="en" lang="en">A virtual line on which almost all glyphs in Western fonts are designed to be aligned. (JIS Z 8125)</p>
             <p its-locale-filter-list="ja" lang="ja">欧文フォントなどにおいて，フォント中の多くのグリフがその上でそろう，基本的な仮想の線．（JIS Z 8125）</p>
           </td>
         </tr>
         <tr id="term.bibliography">
-          <td class="xfq-term">bibliography</td>
-          <td class="xfq-ja">参考文献</td>
-          <td class="xfq-transliteration">sankō bunken<br/>さんこうぶんけん</td>
-          <td class="xfq-def">
+          <td>bibliography</td>
+          <td>参考文献</td>
+          <td>sankō bunken<br/>さんこうぶんけん</td>
+          <td>
             <p its-locale-filter-list="en" lang="en">A list of works and papers related to the subjects in the text. (JIS Z 8125)</p>
             <p its-locale-filter-list="ja" lang="ja">本文の内容に関係の深い他の著書，論文を記したもの．（JIS Z 8125）</p>
           </td>
         </tr>
         <tr id="term.blank-page">
-          <td class="xfq-term">blank page</td>
-          <td class="xfq-ja">白ページ</td>
-          <td class="xfq-transliteration">shiro pēji<br/>しろぺーじ</td>
-          <td class="xfq-def">
+          <td>blank page</td>
+          <td>白ページ</td>
+          <td>shiro pēji<br/>しろぺーじ</td>
+          <td>
             <p its-locale-filter-list="en" lang="en">An empty page.</p>
             <p its-locale-filter-list="ja" lang="ja">何も表示しないページ．</p>
           </td>
         </tr>
         <tr id="term.bleed">
-          <td class="xfq-term">bleed</td>
-          <td class="xfq-ja">裁切り</td>
-          <td class="xfq-transliteration">tachikiri<br/>たちきり</td>
-          <td class="xfq-def">
+          <td>bleed</td>
+          <td>裁切り</td>
+          <td>tachikiri<br/>たちきり</td>
+          <td>
             <p its-locale-filter-list="en" lang="en">To print a picture or a tint to run off the edge of a trimmed page. (JIS Z 8125)</p>
             <p its-locale-filter-list="ja" lang="ja">写真，平網などを断裁位置いっぱいまで印刷すること．（JIS Z 8125）</p>
           </td>
         </tr>
         <tr id="term.block-direction">
-          <td class="xfq-term">block direction</td>
-          <td class="xfq-ja">行送り方向</td>
-          <td class="xfq-transliteration">gyō okuri hōkō<br/>ぎょうおくりほうこう</td>
-          <td class="xfq-def">
+          <td>block direction</td>
+          <td>行送り方向</td>
+          <td>gyō okuri hōkō<br/>ぎょうおくりほうこう</td>
+          <td>
             <p its-locale-filter-list="en" lang="en">The direction lines progress, one after the other. (JIS Z 8125)</p>
             <p its-locale-filter-list="ja" lang="ja">1つの行が次の行へと続く方向．（JIS Z 8125）</p>
           </td>
         </tr>
         <tr id="term.block-heading">
-          <td class="xfq-term">block heading</td>
-          <td class="xfq-ja">別行見出し</td>
-          <td class="xfq-transliteration">betsugyōmidashi<br/>べつぎょうみだし</td>
-          <td class="xfq-def">
+          <td>block heading</td>
+          <td>別行見出し</td>
+          <td>betsugyōmidashi<br/>べつぎょうみだし</td>
+          <td>
             <p its-locale-filter-list="en" lang="en">A kind of heading styles. The heading is set as an independent line from basic text. (JIS Z 8125)</p>
             <p its-locale-filter-list="ja" lang="ja">本文とは別の行に配置した見出し．（JIS Z 8125）</p>
           </td>
         </tr>
         <tr id="term.bold">
-          <td class="xfq-term">bold</td>
-          <td class="xfq-ja">太字</td>
-          <td class="xfq-transliteration">futoji<br/>ふとじ</td>
-          <td class="xfq-def">
+          <td>bold</td>
+          <td>太字</td>
+          <td>futoji<br/>ふとじ</td>
+          <td>
             <p its-locale-filter-list="en" lang="en">A kind of font style. Similer to bold in western typograpy.</p>
             <p its-locale-filter-list="ja" lang="ja">ウェイトを大きく（字形の画線を太く）した書体．</p>
           </td>
         </tr>
         <tr id="term.bound-on-the-left-hand-side">
-          <td class="xfq-term">bound on the left-hand side</td>
-          <td class="xfq-ja">左綴じ</td>
-          <td class="xfq-transliteration">hidari toji<br/>ひだりとじ</td>
-          <td class="xfq-def">
+          <td>bound on the left-hand side</td>
+          <td>左綴じ</td>
+          <td>hidari toji<br/>ひだりとじ</td>
+          <td>
             <p its-locale-filter-list="en" lang="en">Binding of a book to be opened from the left.</p>
             <p its-locale-filter-list="ja" lang="ja">表紙の表面を正面に見た場合に，のどが左側になっている綴じ方．</p>
           </td>
         </tr>
         <tr id="term.bound-on-the-right-hand-side">
-          <td class="xfq-term">bound on the right-hand side</td>
-          <td class="xfq-ja">右綴じ</td>
-          <td class="xfq-transliteration">migi toji<br/>みぎとじ</td>
-          <td class="xfq-def">
+          <td>bound on the right-hand side</td>
+          <td>右綴じ</td>
+          <td>migi toji<br/>みぎとじ</td>
+          <td>
             <p its-locale-filter-list="en" lang="en">Binding of a book to be opened from the right.</p>
             <p its-locale-filter-list="ja" lang="ja">表紙の表面を正面に見た場合に，のどが右側になっている綴じ方．</p>
           </td>
         </tr>
         <tr id="term.bousen">
-          <td class="xfq-term">bousen (sideline)</td>
-          <td class="xfq-ja">傍線</td>
-          <td class="xfq-transliteration">bōsen<br/>ぼうせん</td>
-          <td class="xfq-def">
+          <td>bousen (sideline)</td>
+          <td>傍線</td>
+          <td>bōsen<br/>ぼうせん</td>
+          <td>
             <p its-locale-filter-list="en" lang="en">A line drawn by the left or right side of a character or a run of text in vertical writing mode. (JIS Z 8125)</p>
             <p its-locale-filter-list="ja" lang="ja">縦組において，文字又は文字列の右又は左に引いた線．（JIS Z 8125）</p>
           </td>
         </tr>
         <tr id="term.break">
-          <td class="xfq-term">break (a line)</td>
-          <td class="xfq-ja">（2行に）分割</td>
-          <td class="xfq-transliteration">bunkatsu<br/>ぶんかつ</td>
-          <td class="xfq-def">
+          <td>break (a line)</td>
+          <td>（2行に）分割</td>
+          <td>bunkatsu<br/>ぶんかつ</td>
+          <td>
             <p its-locale-filter-list="en" lang="en">To place the first of two adjacent characters at the end of a line and the second at the head of a new line.</p>
             <p its-locale-filter-list="ja" lang="ja">連続した2文字について，前の文字は，その行の行末に配置し，後ろの文字は次の行の行頭に移動すること．</p>
           </td>
         </tr>
         <tr id="term.caption">
-          <td class="xfq-term">caption</td>
-          <td class="xfq-ja">キャプション</td>
-          <td class="xfq-transliteration">kyapushon<br/>きゃぷしょん</td>
-          <td class="xfq-def">
+          <td>caption</td>
+          <td>キャプション</td>
+          <td>kyapushon<br/>きゃぷしょん</td>
+          <td>
             <p its-locale-filter-list="en" lang="en">A title or a short description accompanying a picture, an illustration, or a table. (JIS Z 8125)</p>
             <p its-locale-filter-list="ja" lang="ja">写真，図版，表などにそえる標題や簡潔な説明文．（JIS Z 8125）</p>
           </td>
         </tr>
         <tr id="term.cell">
-          <td class="xfq-term">cell</td>
-          <td class="xfq-ja">こま</td>
-          <td class="xfq-transliteration">koma<br/>こま</td>
-          <td class="xfq-def">
+          <td>cell</td>
+          <td>こま</td>
+          <td>koma<br/>こま</td>
+          <td>
             <p its-locale-filter-list="en" lang="en">Each element area of tables, cell.</p>
             <p its-locale-filter-list="ja" lang="ja">表においては，罫などで小さな領域に区切るが，この隣り合う縦及び横の罫などで区切られた個々の領域．</p>
           </td>
         </tr>
         <tr id="term.cell-contents">
-          <td class="xfq-term">cell contents</td>
-          <td class="xfq-ja">こま内容</td>
-          <td class="xfq-transliteration">komanaiyō<br/>こまないよう</td>
-          <td class="xfq-def">
+          <td>cell contents</td>
+          <td>こま内容</td>
+          <td>komanaiyō<br/>こまないよう</td>
+          <td>
             <p its-locale-filter-list="en" lang="en">The content of each cell in tables. (JIS X 4051)</p>
             <p its-locale-filter-list="ja" lang="ja">表のこまの中に表示されるもの．（JIS X 4051）</p>
           </td>
         </tr>
         <tr id="term.cell-padding">
-          <td class="xfq-term">cell padding</td>
-          <td class="xfq-ja">こま余白</td>
-          <td class="xfq-transliteration">komayohaku<br/>こまよはく</td>
-          <td class="xfq-def">
+          <td>cell padding</td>
+          <td>こま余白</td>
+          <td>komayohaku<br/>こまよはく</td>
+          <td>
             <p its-locale-filter-list="en" lang="en">Spaces between line and cell in tables. (JIS X 4051)</p>
             <p its-locale-filter-list="ja" lang="ja">表の罫線とこまとの間の空白領域．（JIS X 4051）</p>
           </td>
         </tr>
         <tr id="term.centering">
-          <td class="xfq-term">centering</td>
-          <td class="xfq-ja">中央そろえ</td>
-          <td class="xfq-transliteration">chūō soroe<br/>ちゅうおうそろえ</td>
-          <td class="xfq-def">
+          <td>centering</td>
+          <td>中央そろえ</td>
+          <td>chūō soroe<br/>ちゅうおうそろえ</td>
+          <td>
             <p its-locale-filter-list="en" lang="en">To align the center of a run of text that is shorter than a given line length to the center of a line. (JIS Z 8125)</p>
             <p its-locale-filter-list="ja" lang="ja">文字列の中央を，行頭と行末との中央の位置に合わせること．（JIS Z 8125）</p>
           </td>
         </tr>
         <tr id="term.character-advance">
-          <td class="xfq-term">character advance</td>
-          <td class="xfq-ja">字幅</td>
-          <td class="xfq-transliteration">jihaba<br/>じはば</td>
-          <td class="xfq-def">
+          <td>character advance</td>
+          <td>字幅</td>
+          <td>jihaba<br/>じはば</td>
+          <td>
             <p its-locale-filter-list="en" lang="en">Size of a character frame in the inline direction, generally indicated as a ratio of the size of a full-width character, as in full-width, half-width, or quarter em width. Character advance is the width of a given character in horizontal writing-mode, while it is the height in vertical writing-mode.</p>
             <p its-locale-filter-list="ja" lang="ja">字幅が，全角の2分の1である文字の外枠．（JIS X 4051）</p>
           </td>
         </tr>
         <tr id="term.character-frame">
-          <td class="xfq-term">character frame</td>
-          <td class="xfq-ja">（文字の）外枠</td>
-          <td class="xfq-transliteration">sotowaku<br/>そとわく</td>
-          <td class="xfq-def">
+          <td>character frame</td>
+          <td>（文字の）外枠</td>
+          <td>sotowaku<br/>そとわく</td>
+          <td>
             <p its-locale-filter-list="en" lang="en">Rectangular area occupied by a character when it is set solid.</p>
             <p its-locale-filter-list="ja" lang="ja">1つの文字が組版の際に占有する仮想的な長方形の領域．</p>
           </td>
         </tr>
         <tr id="term.character-shape">
-          <td class="xfq-term">character shape</td>
-          <td class="xfq-ja">字形</td>
-          <td class="xfq-transliteration">jikei<br/></td>
-          <td class="xfq-def">
+          <td>character shape</td>
+          <td>字形</td>
+          <td>jikei<br/></td>
+          <td>
             <p its-locale-filter-list="en" lang="en">Incarnation of a character by handwriting, printing or rendering to a computer screen. (JIS Z 8125)</p>
             <p its-locale-filter-list="ja" lang="ja">文字について，手書き，印字，画面表示などによって実際に図形として表現したもの．（JIS Z 8125）</p>
           </td>
         </tr>
         <tr id="term.character-size">
-          <td class="xfq-term">character size</td>
-          <td class="xfq-ja">文字サイズ</td>
-          <td class="xfq-transliteration">moji saizu<br/>もじさいず</td>
-          <td class="xfq-def">
+          <td>character size</td>
+          <td>文字サイズ</td>
+          <td>moji saizu<br/>もじさいず</td>
+          <td>
             <p its-locale-filter-list="en" lang="en">Dimensions of a character. Unless otherwise noted, it refers to the size of a character frame in the block direction.</p>
             <p its-locale-filter-list="ja" lang="ja">文字の大きさ．通常，文字の行送り方向の外枠の長さ．</p>
           </td>
         </tr>
         <tr id="term.characters-not-ending-line">
-          <td class="xfq-term">characters not ending line</td>
-          <td class="xfq-ja">行末禁則文字</td>
-          <td class="xfq-transliteration">gyōmatsu kinsoku moji<br/></td>
-          <td class="xfq-def">
+          <td>characters not ending line</td>
+          <td>行末禁則文字</td>
+          <td>gyōmatsu kinsoku moji<br/></td>
+          <td>
             <p its-locale-filter-list="en" lang="en">Any character for which "line-end prohibition rule" is invoked. (JIS Z 8125)</p>
             <p its-locale-filter-list="ja" lang="ja">行末禁則の条件に該当する文字．（JIS Z 8125）</p>
           </td>
         </tr>
         <tr id="term.characters-not-starting-line">
-          <td class="xfq-term">characters not starting line</td>
-          <td class="xfq-ja">行頭禁則文字</td>
-          <td class="xfq-transliteration">gyōtō kinsoku moji<br/>ぎょうとうきんそくもじ</td>
-          <td class="xfq-def">
+          <td>characters not starting line</td>
+          <td>行頭禁則文字</td>
+          <td>gyōtō kinsoku moji<br/>ぎょうとうきんそくもじ</td>
+          <td>
             <p its-locale-filter-list="en" lang="en">Any character for which "line-start prohibition rule" is invoked. (JIS Z 8125)</p>
             <p its-locale-filter-list="ja" lang="ja">行頭禁則の条件に該当する文字．（JIS Z 8125）</p>
           </td>
         </tr>
         <tr id="term.chronological-history">
-          <td class="xfq-term">chronological history</td>
-          <td class="xfq-ja">年譜</td>
-          <td class="xfq-transliteration">nenpu<br/>ねんぷ</td>
-          <td class="xfq-def">
+          <td>chronological history</td>
+          <td>年譜</td>
+          <td>nenpu<br/>ねんぷ</td>
+          <td>
             <p its-locale-filter-list="en" lang="en">Chronological tabels about the histories of persons or organizations.</p>
             <p its-locale-filter-list="ja" lang="ja">個人（又は団体）の経歴について，年代順に記載した表．</p>
           </td>
         </tr>
         <tr id="term.chronological-table">
-          <td class="xfq-term">chronological table</td>
-          <td class="xfq-ja">年表</td>
-          <td class="xfq-transliteration">nenpyō<br/>ねんぴょう</td>
-          <td class="xfq-def">
+          <td>chronological table</td>
+          <td>年表</td>
+          <td>nenpyō<br/>ねんぴょう</td>
+          <td>
             <p its-locale-filter-list="en" lang="en">Chronologocal tables about histrical incidents. There are special types of chronological tables besides general ones, focused to specific view points and aspects.</p>
             <p its-locale-filter-list="ja" lang="ja">歴史上の諸事件について，年代順に記載した表．年表には，社会全般の諸事件を対象とした総合年表だけでなく，目的に応じて特定の分野に限定した特殊年表がある．</p>
           </td>
         </tr>
         <tr id="term.chu-boso-kei">
-          <td class="xfq-term">chu-boso-kei</td>
-          <td class="xfq-ja">中細罫</td>
-          <td class="xfq-transliteration">chūbosokei<br/>ちゅうぼそけい</td>
-          <td class="xfq-def">
+          <td>chu-boso-kei</td>
+          <td>中細罫</td>
+          <td>chūbosokei<br/>ちゅうぼそけい</td>
+          <td>
             <p its-locale-filter-list="en" lang="en">Middle width line, usually about 0.25mm.</p>
             <p its-locale-filter-list="ja" lang="ja">0.25mm程度の太さの実線．</p>
           </td>
         </tr>
         <tr id="term.column">
-          <td class="xfq-term">column</td>
-          <td class="xfq-ja">段</td>
-          <td class="xfq-transliteration">dan<br/>だん</td>
-          <td class="xfq-def">
+          <td>column</td>
+          <td>段</td>
+          <td>dan<br/>だん</td>
+          <td>
             <p its-locale-filter-list="en" lang="en">A partition on a page in multi-column format. (JIS Z 8125)</p>
             <p its-locale-filter-list="ja" lang="ja">段組において，分割された1区分．（JIS Z 8125）</p>
           </td>
         </tr>
         <tr id="term.column-gap">
-          <td class="xfq-term">column gap</td>
-          <td class="xfq-ja">段間</td>
-          <td class="xfq-transliteration">dankan<br/>だんかん</td>
-          <td class="xfq-def">
+          <td>column gap</td>
+          <td>段間</td>
+          <td>dankan<br/>だんかん</td>
+          <td>
             <p its-locale-filter-list="en" lang="en">Amount of space between columns on a page. (JIS Z 8125)</p>
             <p its-locale-filter-list="ja" lang="ja">段組の段と段との間の空き．（JIS Z 8125）</p>
           </td>
         </tr>
         <tr id="term.column-spanning">
-          <td class="xfq-term">column spanning</td>
-          <td class="xfq-ja">段抜き</td>
-          <td class="xfq-transliteration">dannuki<br/>だんぬき</td>
-          <td class="xfq-def">
+          <td>column spanning</td>
+          <td>段抜き</td>
+          <td>dannuki<br/>だんぬき</td>
+          <td>
             <p its-locale-filter-list="en" lang="en">A setting style of illustrations, tables, etc., over hanging to multiple columns. (JIS Z 8125)</p>
             <p its-locale-filter-list="ja" lang="ja">段組のページにおいて，見出し，図版などを複数段にまたがって配置すること．（JIS Z 8125）</p>
           </td>
         </tr>
         <tr id="term.column-spanning-heading">
-          <td class="xfq-term">column spanning heading</td>
-          <td class="xfq-ja">段抜きの見出し</td>
-          <td class="xfq-transliteration">dannuki no midashi<br/>だんぬきのみだし</td>
-          <td class="xfq-def">
+          <td>column spanning heading</td>
+          <td>段抜きの見出し</td>
+          <td>dannuki no midashi<br/>だんぬきのみだし</td>
+          <td>
             <p its-locale-filter-list="en" lang="en">Headings using multiple columns.</p>
             <p its-locale-filter-list="ja" lang="ja">段抜きにして配置する見出し．</p>
           </td>
         </tr>
         <tr id="term.composition">
-          <td class="xfq-term">composition</td>
-          <td class="xfq-ja">組版</td>
-          <td class="xfq-transliteration">kumihan<br/>くみはん</td>
-          <td class="xfq-def">
+          <td>composition</td>
+          <td>組版</td>
+          <td>kumihan<br/>くみはん</td>
+          <td>
             <p its-locale-filter-list="en" lang="en">Process of arrangement of text, figures and/or pictures, etc on a page in a desired layout (design) in preparation for printing.</p>
             <p its-locale-filter-list="ja" lang="ja">原稿及びレイアウト（デザイン）の指定に従って，文字・図版・写真などを配置する作業の総称．</p>
           </td>
         </tr>
         <tr id="term.compound-word">
-          <td class="xfq-term">compound word (jukugo)</td>
-          <td class="xfq-ja">熟語</td>
-          <td class="xfq-transliteration">jukugo<br/>じゅくご</td>
-          <td class="xfq-def">
+          <td>compound word (jukugo)</td>
+          <td>熟語</td>
+          <td>jukugo<br/>じゅくご</td>
+          <td>
             <p its-locale-filter-list="en" lang="en">A combination of two or more kanji characters which makes one word.</p>
             <p its-locale-filter-list="ja" lang="ja">2字以上の漢字が結合し，一語となったもの．</p>
           </td>
         </tr>
         <tr id="term.continuous-pagination">
-          <td class="xfq-term">continuous pagination</td>
-          <td class="xfq-ja">通しノンブル</td>
-          <td class="xfq-transliteration">tōshi nonburu<br/>とおしのんぶる</td>
-          <td class="xfq-def">
+          <td>continuous pagination</td>
+          <td>通しノンブル</td>
+          <td>tōshi nonburu<br/>とおしのんぶる</td>
+          <td>
             <div its-locale-filter-list="en" lang="en">
               <div>a) To number the pages of a book continuously across all those in the front matter, the text and the back matter.</div>
               <div>b) To number the pages continuously across those of all books, such as a series published in separate volumes. Also to number the pages continuously across those of all issues of a periodical published in a year, aside from pagination per issue.</div>
@@ -23062,118 +23062,118 @@
           </td>
         </tr>
         <tr id="term.drop-heading">
-          <td class="xfq-term">cut-in heading</td>
-          <td class="xfq-ja">窓見出し</td>
-          <td class="xfq-transliteration">madomidashi<br/>まどみだし</td>
-          <td class="xfq-def">
+          <td>cut-in heading</td>
+          <td>窓見出し</td>
+          <td>madomidashi<br/>まどみだし</td>
+          <td>
             <p its-locale-filter-list="en" lang="en">A style of headings. Headings do not occupy the full lines, but share lines area with following main text lines.</p>
             <p its-locale-filter-list="ja" lang="ja">見出しだけで1行を構成することなく，見出しの次に2行又は3行の文章を続ける見出し．</p>
           </td>
         </tr>
         <tr id="term.descender-line">
-          <td class="xfq-term">descender line</td>
-          <td class="xfq-ja">ディセンダライン</td>
-          <td class="xfq-transliteration">disenda rain<br/>でぃせんだらいん</td>
-          <td class="xfq-def">
+          <td>descender line</td>
+          <td>ディセンダライン</td>
+          <td>disenda rain<br/>でぃせんだらいん</td>
+          <td>
             <p its-locale-filter-list="en" lang="en">A descender is the part of a letter extending below the base line, as in 'g', 'j', 'p', 'q', or 'y'.  A descender line is a virtual line drawn at the bottom of descender parallel to base line.</p>
             <p its-locale-filter-list="ja" lang="ja">ディセンダは，欧文小文字のg，j，p，q，yなどの文字の，ベースラインより下に伸びている部分をいい，ディセンダラインは，ディセンダの最下端を示す，ベースラインに平行な仮想の線．</p>
           </td>
         </tr>
         <tr id="term.double-running-head-method">
-          <td class="xfq-term">double running head method</td>
-          <td class="xfq-ja">両柱方式</td>
-          <td class="xfq-transliteration">ryōbashira hōshiki<br/>りょうばしらほうしき</td>
-          <td class="xfq-def">
+          <td>double running head method</td>
+          <td>両柱方式</td>
+          <td>ryōbashira hōshiki<br/>りょうばしらほうしき</td>
+          <td>
             <p its-locale-filter-list="en" lang="en">A method that prints running heads on both even and odd pages. (JIS Z 8125)</p>
             <p its-locale-filter-list="ja" lang="ja">柱を奇数・偶数両ページに掲げること．（JIS Z 8125）</p>
           </td>
         </tr>
         <tr id="term.emphasis-dots">
-          <td class="xfq-term">emphasis dots</td>
-          <td class="xfq-ja">圏点</td>
-          <td class="xfq-transliteration">kenten<br/>けんてん</td>
-          <td class="xfq-def">
+          <td>emphasis dots</td>
+          <td>圏点</td>
+          <td>kenten<br/>けんてん</td>
+          <td>
             <p its-locale-filter-list="en" lang="en">Symbols attached alongside a run of base characters to emphasize them. (JIS Z 8125)</p>
             <p its-locale-filter-list="ja" lang="ja">文字のそばに付けて注意を促したり，その部分を強調したりするしるし．（JIS Z 8125）</p>
           </td>
         </tr>
         <tr id="term.endnote">
-          <td class="xfq-term">endnote</td>
-          <td class="xfq-ja">後注</td>
-          <td class="xfq-transliteration">kōchū<br/>こうちゅう</td>
-          <td class="xfq-def">
+          <td>endnote</td>
+          <td>後注</td>
+          <td>kōchū<br/>こうちゅう</td>
+          <td>
             <p its-locale-filter-list="en" lang="en">A set of notes placed at the end of a part, chapter, section, paragraph and so on, or at the end of a book. (JIS Z 8125)</p>
             <p its-locale-filter-list="ja" lang="ja">本文の編・章・節・段落などの区分の終わり又は巻末にまとめて入れる注釈．（JIS Z 8125）</p>
           </td>
         </tr>
         <tr id="term.european-numerals">
-          <td class="xfq-term">European numerals</td>
-          <td class="xfq-ja">アラビア数字</td>
-          <td class="xfq-transliteration">arabia sūji<br/>あらびあすうじ</td>
-          <td class="xfq-def">
+          <td>European numerals</td>
+          <td>アラビア数字</td>
+          <td>arabia sūji<br/>あらびあすうじ</td>
+          <td>
             <p its-locale-filter-list="en" lang="en">Any of the symbols in [0-9] used to represent numbers. (JIS Z 8125)</p>
             <p its-locale-filter-list="ja" lang="ja">インドに始まり，アラビアからヨーロッパに伝わった数字．（算用数字，洋数字ともいう．）（JIS Z 8125）</p>
           </td>
         </tr>
         <tr id="term.even-inter-character-spacing">
-          <td class="xfq-term">even inter-character spacing</td>
-          <td class="xfq-ja">均等割り</td>
-          <td class="xfq-transliteration">kintō wari<br/>きんとうわり</td>
-          <td class="xfq-def">
+          <td>even inter-character spacing</td>
+          <td>均等割り</td>
+          <td>kintō wari<br/>きんとうわり</td>
+          <td>
             <p its-locale-filter-list="en" lang="en">A text setting with uniform inter-character spacing per line so that each line is aligned on the same line-head and line-end. (JIS Z 8125)</p>
             <p its-locale-filter-list="ja" lang="ja">字間を均等に空け，文字列の両端を行頭及び行末にそろえること．（JIS Z 8125）</p>
           </td>
         </tr>
         <tr id="term.even-tsumegumi">
-          <td class="xfq-term">even tsumegumi</td>
-          <td class="xfq-ja">均等詰め</td>
-          <td class="xfq-transliteration">kintō zume<br/>きんとうづめ</td>
-          <td class="xfq-def">
+          <td>even tsumegumi</td>
+          <td>均等詰め</td>
+          <td>kintō zume<br/>きんとうづめ</td>
+          <td>
             <p its-locale-filter-list="en" lang="en">Adjustment of inter-character space by subtracting the same amount of space. (JIS Z 8125)</p>
             <p its-locale-filter-list="ja" lang="ja">ベタ組より字間を一定量詰めて文字を配置する方法．（JIS Z 8125）</p>
           </td>
         </tr>
         <tr id="term.face-tsumegumi">
-          <td class="xfq-term">face tsumegumi</td>
-          <td class="xfq-ja">字面詰め</td>
-          <td class="xfq-transliteration">jizura zume<br/>じづらづめ</td>
-          <td class="xfq-def">
+          <td>face tsumegumi</td>
+          <td>字面詰め</td>
+          <td>jizura zume<br/>じづらづめ</td>
+          <td>
             <p its-locale-filter-list="en" lang="en">Adjustment of inter-character space by subtracting space to the extent that two letter faces are placed adjacent. (JIS Z 8125)</p>
             <p its-locale-filter-list="ja" lang="ja">仮名や約物等の字面が重ならない程度まで詰めて文字を配置する方法．（JIS Z 8125）</p>
           </td>
         </tr>
         <tr id="term.fixed-inter-character-spacing">
-          <td class="xfq-term">fixed inter-character spacing</td>
-          <td class="xfq-ja">アキ組</td>
-          <td class="xfq-transliteration">aki gumi<br/>あきぐみ</td>
-          <td class="xfq-def">
+          <td>fixed inter-character spacing</td>
+          <td>アキ組</td>
+          <td>aki gumi<br/>あきぐみ</td>
+          <td>
             <p its-locale-filter-list="en" lang="en">A text setting with a uniform inter-character spacing. (JIS Z 8125)</p>
             <p its-locale-filter-list="ja" lang="ja">字間に一定のアキを入れて文字を配置する方法．（JIS Z 8125）</p>
           </td>
         </tr>
         <tr id="term.fixed-width">
-          <td class="xfq-term">fixed-width</td>
-          <td class="xfq-ja">モノスペース</td>
-          <td class="xfq-transliteration">monosupēsu<br/>ものすぺーす</td>
-          <td class="xfq-def">
+          <td>fixed-width</td>
+          <td>モノスペース</td>
+          <td>monosupēsu<br/>ものすぺーす</td>
+          <td>
             <p its-locale-filter-list="en" lang="en">A characteristic of a font where the same character advance is assigned for all glyphs. (JIS Z 8125)</p>
             <p its-locale-filter-list="ja" lang="ja">1つのフォントの文字の字幅がすべて等しい値を持っていること．（JIS Z 8125）</p>
           </td>
         </tr>
         <tr id="term.font">
-          <td class="xfq-term">font</td>
-          <td class="xfq-ja">フォント</td>
-          <td class="xfq-transliteration">fonto<br/>ふぉんと</td>
-          <td class="xfq-def">
+          <td>font</td>
+          <td>フォント</td>
+          <td>fonto<br/>ふぉんと</td>
+          <td>
             <p its-locale-filter-list="en" lang="en">A set of character glyphs of a given typeface. (JIS Z 8125)</p>
             <p its-locale-filter-list="ja" lang="ja">ある書体によって作成された字形の集合．（JIS Z 8125）</p>
           </td>
         </tr>
         <tr id="term.foot">
-            <td class="xfq-term">foot</td>
-            <td class="xfq-ja">地</td>
-            <td class="xfq-transliteration">chi<br/>ち</td>
-            <td class="xfq-def">
+            <td>foot</td>
+            <td>地</td>
+            <td>chi<br/>ち</td>
+            <td>
               <div its-locale-filter-list="en" lang="en">
                   <div>a) The bottom part of a book or a page.</div>
                   <div>b) The bottom margin between the edge of a trimmed page and the hanmen (text area)</div>
@@ -23187,19 +23187,19 @@
             </td>
           </tr>
           <tr id="term.footnote">
-            <td class="xfq-term">footnote</td>
-            <td class="xfq-ja">脚注</td>
-            <td class="xfq-transliteration">kyakuchū<br/>きゃくちゅう</td>
-            <td class="xfq-def">
+            <td>footnote</td>
+            <td>脚注</td>
+            <td>kyakuchū<br/>きゃくちゅう</td>
+            <td>
               <p its-locale-filter-list="en" lang="en">A note in a smaller face than that of main text, placed at the bottom of a page. (JIS Z 8125)</p>
               <p its-locale-filter-list="ja" lang="ja">ページの下部に，本文よりも小さな文字で組まれた注釈．（JIS Z 8125）</p>
             </td>
           </tr>
           <tr id="term.fore-edge">
-            <td class="xfq-term">fore-edge</td>
-            <td class="xfq-ja">小口</td>
-            <td class="xfq-transliteration">koguchi<br/>こぐち</td>
-            <td class="xfq-def">
+            <td>fore-edge</td>
+            <td>小口</td>
+            <td>koguchi<br/>こぐち</td>
+            <td>
               <div its-locale-filter-list="en" lang="en">
                   <div>a) The three front trimmed edges of pages in a book.</div>
                   <div>b) The opposite sides of the gutter in a book.</div>
@@ -23213,19 +23213,19 @@
             </td>
           </tr>
           <tr id="term.front-matter">
-            <td class="xfq-term">front matter</td>
-            <td class="xfq-ja">前付</td>
-            <td class="xfq-transliteration">maezuke<br/>まえづけ</td>
-            <td class="xfq-def">
+            <td>front matter</td>
+            <td>前付</td>
+            <td>maezuke<br/>まえづけ</td>
+            <td>
               <p its-locale-filter-list="en" lang="en">The first part of a book followed by the text, usually consisting of a forward, preface, table of contents, list of illustrations, acknowledgement and so on. </p>
               <p its-locale-filter-list="ja" lang="ja">書籍の本文に先立つページで，まえがき，序文，目次，挿絵一覧，献辞など．</p>
             </td>
           </tr>
           <tr id="term.full-width">
-            <td class="xfq-term">full-width</td>
-            <td class="xfq-ja">全角</td>
-            <td class="xfq-transliteration">zenkaku<br/>ぜんかく</td>
-            <td class="xfq-def">
+            <td>full-width</td>
+            <td>全角</td>
+            <td>zenkaku<br/>ぜんかく</td>
+            <td>
               <div its-locale-filter-list="en" lang="en">
                   <div>a) Relative index for the length which is equal to a given character size.</div>
                   <div>b) Character frame which character advance is equal to the amount referred to as a). A full-width character frame is  square in shape by definition.</div>
@@ -23237,55 +23237,55 @@
             </td>
           </tr>
           <tr id="term.furigana">
-            <td class="xfq-term">furigana</td>
-            <td class="xfq-ja">振り仮名</td>
-            <td class="xfq-transliteration">furigana<br/></td>
-            <td class="xfq-def">
+            <td>furigana</td>
+            <td>振り仮名</td>
+            <td>furigana<br/></td>
+            <td>
               <p its-locale-filter-list="en" lang="en">A method of ruby annotation using kana characters to indicate how to read kanji characters. This term derives from a Japanese verb "furu (to attach alongside)" and "kana", and has been used synonymously with "ruby". This document prefers to use the term "ruby".</p>
               <p its-locale-filter-list="ja" lang="ja">ルビの配置位置に，仮名を使用したもの．なお，振り仮名とは，漢字の読み方を示すために，そのわきに付ける仮名という意味で，ルビと同義的に用いられてきた．この文書では“ルビ”という用語を一貫して用いる．</p>
             </td>
           </tr>
           <tr id="term.furikanji">
-            <td class="xfq-term">furikanji</td>
-            <td class="xfq-ja">振り漢字</td>
-            <td class="xfq-transliteration">furikanji<br/>ふりがな</td>
-            <td class="xfq-def">
+            <td>furikanji</td>
+            <td>振り漢字</td>
+            <td>furikanji<br/>ふりがな</td>
+            <td>
               <p its-locale-filter-list="en" lang="en">A method of ruby annotation using Kanji characters for ruby instead of kana characters.</p>
               <p its-locale-filter-list="ja" lang="ja">ルビの配置位置に，仮名ではなく，漢字を使用したもの．</p>
             </td>
           </tr>
           <tr id="term.furiwake">
-            <td class="xfq-term">furiwake</td>
-            <td class="xfq-ja">振分け</td>
-            <td class="xfq-transliteration">furiwake<br/>ふりわけ</td>
-            <td class="xfq-def">
+            <td>furiwake</td>
+            <td>振分け</td>
+            <td>furiwake<br/>ふりわけ</td>
+            <td>
               <p its-locale-filter-list="en" lang="en">A method of placing multiple runs of text in a line. (JIS Z 8125)</p>
               <p its-locale-filter-list="ja" lang="ja">1行の中に，複数の行からなる文章を配置する方法．（JIS Z 8125）</p>
             </td>
           </tr>
           <tr id="term.general-ruby">
-            <td class="xfq-term">general-ruby</td>
-            <td class="xfq-ja">総ルビ</td>
-            <td class="xfq-transliteration">sō rubi<br/>そうるび</td>
-            <td class="xfq-def">
+            <td>general-ruby</td>
+            <td>総ルビ</td>
+            <td>sō rubi<br/>そうるび</td>
+            <td>
               <p its-locale-filter-list="en" lang="en">A method of ruby annotation that attaches ruby text for all Kanji characters in the text. (JIS Z 8125)</p>
               <p its-locale-filter-list="ja" lang="ja">文中のすべての漢字にルビを付けること．（JIS Z 8125）</p>
             </td>
           </tr>
           <tr id="term.group-ruby">
-            <td class="xfq-term">group-ruby</td>
-            <td class="xfq-ja">グループルビ</td>
-            <td class="xfq-transliteration">gurūpu rubi<br/>ぐるーぷるび</td>
-            <td class="xfq-def">
+            <td>group-ruby</td>
+            <td>グループルビ</td>
+            <td>gurūpu rubi<br/>ぐるーぷるび</td>
+            <td>
               <p its-locale-filter-list="en" lang="en">A method of ruby character distribution such that the length of ruby text matches to that of the base text by giving the same adjusted amount of space between ruby characters.</p>
               <p its-locale-filter-list="ja" lang="ja">複数の親文字で構成される語全体に掛かるように均等間隔にルビを付けて配置する方法．</p>
             </td>
           </tr>
           <tr id="term.gutter">
-            <td class="xfq-term">gutter</td>
-            <td class="xfq-ja">のど</td>
-            <td class="xfq-transliteration">nodo<br/>のど</td>
-            <td class="xfq-def">
+            <td>gutter</td>
+            <td>のど</td>
+            <td>nodo<br/>のど</td>
+            <td>
               <div its-locale-filter-list="en" lang="en">
                   <div>a) The binding side of a spread of a book.</div>
                   <div>b) The margin between the binding edge of a book and the hanmen (text area).</div>
@@ -23301,64 +23301,64 @@
             </td>
           </tr>
           <tr id="term.gyodori">
-            <td class="xfq-term">gyodori</td>
-            <td class="xfq-ja">行取り</td>
-            <td class="xfq-transliteration">gyōdori<br/>ぎょうどり</td>
-            <td class="xfq-def">
+            <td>gyodori</td>
+            <td>行取り</td>
+            <td>gyōdori<br/>ぎょうどり</td>
+            <td>
               <p its-locale-filter-list="en" lang="en">To keep block direction area for headings and so on, along with line units in kihon-hanmen. The width of the gyodori space is calculated with following fomula: line width × number of lines + line gap × (number of lines − 1). However, deceptively, in middle of page or column, the line gaps before and after seem to be added to the gyodori space, and in the start of page or column, the line gap after seems to be added to the gyodori space.</p>
               <p its-locale-filter-list="ja" lang="ja">見出しなどを配置する領域の行送り方向の大きさを行単位で確保すること．この場合，行送り方向の見出しの占めるスペースは，“行の幅×行数＋行間×（行数－1）”となる．しかし，見た目には，ページ（又は段）の途中に見出しを配置する場合は，そのスペースの前及び後ろの行間が加わり，ページ（又は段）の先頭に見出しを配置する場合は，そのスペースの後ろの行間が加わった大きさとなる．</p>
             </td>
           </tr>
           <tr id="term.half-em">
-            <td class="xfq-term">half em</td>
-            <td class="xfq-ja">二分</td>
-            <td class="xfq-transliteration">nibu<br/>にぶ</td>
-            <td class="xfq-def">
+            <td>half em</td>
+            <td>二分</td>
+            <td>nibu<br/>にぶ</td>
+            <td>
               <p its-locale-filter-list="en" lang="en">Half of the full-width size. (JIS Z 8125)</p>
               <p its-locale-filter-list="ja" lang="ja">全角の2分の1の長さ．（JIS Z 8125）</p>
             </td>
           </tr>
           <tr id="term.half-em-space">
-            <td class="xfq-term">half em space</td>
-            <td class="xfq-ja">二分アキ</td>
-            <td class="xfq-transliteration">nibu aki<br/>にぶあき</td>
-            <td class="xfq-def">
+            <td>half em space</td>
+            <td>二分アキ</td>
+            <td>nibu aki<br/>にぶあき</td>
+            <td>
               <p its-locale-filter-list="en" lang="en">Amount of space that is half size of em space.</p>
               <p its-locale-filter-list="ja" lang="ja">二分の空き量．</p>
             </td>
           </tr>
           <tr id="term.half-width">
-            <td class="xfq-term">half-width</td>
-            <td class="xfq-ja">半角</td>
-            <td class="xfq-transliteration">hankaku<br/>はんかく</td>
-            <td class="xfq-def">
+            <td>half-width</td>
+            <td>半角</td>
+            <td>hankaku<br/>はんかく</td>
+            <td>
               <p its-locale-filter-list="en" lang="en">Character frame which has a character advance of a half em.</p>
               <p its-locale-filter-list="ja" lang="ja">字幅が，全角の2分の1である文字の外枠．（JIS X 4051）</p>
             </td>
           </tr>
           <tr id="term.han-tobira">
-            <td class="xfq-term">han-tobira</td>
-            <td class="xfq-ja">半扉</td>
-            <td class="xfq-transliteration">hantobira<br/>はんとびら</td>
-            <td class="xfq-def">
+            <td>han-tobira</td>
+            <td>半扉</td>
+            <td>hantobira<br/>はんとびら</td>
+            <td>
               <p its-locale-filter-list="en" lang="en">A simplified version of naka-tobira, the verso side of which text of the new part starts. (JIS Z 8125)</p>
               <p its-locale-filter-list="ja" lang="ja">中扉を簡略にしたもので，裏面から本文を始める，見出しなどの標題を掲げたページ．（JIS Z 8125）</p>
             </td>
           </tr>
           <tr id="term.hanmen">
-            <td class="xfq-term">hanmen (page content area)</td>
-            <td class="xfq-ja">版面</td>
-            <td class="xfq-transliteration">hanmen<br/>はんめん</td>
-            <td class="xfq-def">
+            <td>hanmen (page content area)</td>
+            <td>版面</td>
+            <td>hanmen<br/>はんめん</td>
+            <td>
               <p its-locale-filter-list="en" lang="en">Actual printed area in a page excluding the margins. (note: Running heads and page numbers are not part of hanmen.) (JIS Z 8125)</p>
               <p its-locale-filter-list="ja" lang="ja">本の1ページ内の，周囲の余白を除いた部分の印刷面．（参考：柱及びノンブルは版面に含めない．）（JIS Z 8125）</p>
             </td>
           </tr>
           <tr id="term.head">
-            <td class="xfq-term">head</td>
-            <td class="xfq-ja">天</td>
-            <td class="xfq-transliteration">ten<br/>てん</td>
-            <td class="xfq-def">
+            <td>head</td>
+            <td>天</td>
+            <td>ten<br/>てん</td>
+            <td>
               <div its-locale-filter-list="en" lang="en">
                   <div>a) The top part of a book or a page.</div>
                   <div>b) The top margin between the top edge of a trimmed page and the hanmen (text area)</div>
@@ -23372,10 +23372,10 @@
             </td>
           </tr>
           <tr id="term.heading">
-            <td class="xfq-term">heading</td>
-            <td class="xfq-ja">見出し</td>
-            <td class="xfq-transliteration">midashi<br/>みだし</td>
-            <td class="xfq-def">
+            <td>heading</td>
+            <td>見出し</td>
+            <td>midashi<br/>みだし</td>
+            <td>
               <div its-locale-filter-list="en" lang="en">
                   <div>a) A title of a paper or an article.</div>
                   <div>b) A title for each section of a book, paper or article.</div>
@@ -23389,370 +23389,370 @@
             </td>
           </tr>
           <tr id="term.headnote">
-            <td class="xfq-term">headnote</td>
-            <td class="xfq-ja">頭注</td>
-            <td class="xfq-transliteration">tōchū<br/>とうちゅう</td>
-            <td class="xfq-def">
+            <td>headnote</td>
+            <td>頭注</td>
+            <td>tōchū<br/>とうちゅう</td>
+            <td>
               <p its-locale-filter-list="en" lang="en">A kind of notes in vertical writing style, head area in kihon-hanmen is kept beforehand, and notes are set with smaller size font than main text.</p>
               <p its-locale-filter-list="ja" lang="ja">縦組において，基本版面内の上部に注を配置するための領域をあらかじめ設定し，その領域に本文よりも小さな文字サイズにして掲げる注．</p>
             </td>
           </tr>
           <tr id="term.horizontal-writing-mode">
-            <td class="xfq-term">horizontal writing mode</td>
-            <td class="xfq-ja">横組</td>
-            <td class="xfq-transliteration">yokogumi<br/>よこぐみ</td>
-            <td class="xfq-def">
+            <td>horizontal writing mode</td>
+            <td>横組</td>
+            <td>yokogumi<br/>よこぐみ</td>
+            <td>
               <p its-locale-filter-list="en" lang="en">The process or the result of arranging characters on a line from left to right, of lines on a page from top to bottom, and/or of columns on a page from left to right. (JIS Z 8125)</p>
               <p its-locale-filter-list="ja" lang="ja">行においては文字を水平方向に左から右へ，ページにおいて行を上から下へ，段を左から右へ配列すること．また，そのように文字が配置された状態．（JIS Z 8125）</p>
             </td>
           </tr>
           <tr id="term.hyphenation">
-            <td class="xfq-term">hyphenation</td>
-            <td class="xfq-ja">ハイフネーション</td>
-            <td class="xfq-transliteration">haifunēshon<br/>はいふねーしょん</td>
-            <td class="xfq-def">
+            <td>hyphenation</td>
+            <td>ハイフネーション</td>
+            <td>haifunēshon<br/>はいふねーしょん</td>
+            <td>
               <p its-locale-filter-list="en" lang="en">A method of breaking a line by dividing a Western word at the end of a line and adding a hyphen  at the end of the first half of the syllable. </p>
               <p its-locale-filter-list="ja" lang="ja">行末にかかった欧文の単語について，音節などに従い分綴可能な位置にハイフンを挿入し，2行に分割する処理．</p>
             </td>
           </tr>
           <tr id="term.ideographic-numerals">
-            <td class="xfq-term">ideographic numerals</td>
-            <td class="xfq-ja">漢数字</td>
-            <td class="xfq-transliteration">kansūji<br/>かんすうじ</td>
-            <td class="xfq-def">
+            <td>ideographic numerals</td>
+            <td>漢数字</td>
+            <td>kansūji<br/>かんすうじ</td>
+            <td>
               <p its-locale-filter-list="en" lang="en">Ideographic characters representing numbers.</p>
               <p its-locale-filter-list="ja" lang="ja">漢字の一二三…十などを用いて表す数字．</p>
             </td>
           </tr>
           <tr id="term.illustrations">
-            <td class="xfq-term">illustrations</td>
-            <td class="xfq-ja">図版</td>
-            <td class="xfq-transliteration">zuhan<br/>ずはん</td>
-            <td class="xfq-def">
+            <td>illustrations</td>
+            <td>図版</td>
+            <td>zuhan<br/>ずはん</td>
+            <td>
               <p its-locale-filter-list="en" lang="en">A general term referring to a diagram, chart, cut, figure, picture and the like, to be used for printed materials.</p>
               <p its-locale-filter-list="ja" lang="ja">印刷物の中に掲げる図，グラフ，カット，イラストレーション，写真などの総称．</p>
             </td>
           </tr>
           <tr id="term.independent-pagination">
-            <td class="xfq-term">independent pagination</td>
-            <td class="xfq-ja">別ノンブル</td>
-            <td class="xfq-transliteration">betsu nonburu<br/>べつのんぶる</td>
-            <td class="xfq-def">
+            <td>independent pagination</td>
+            <td>別ノンブル</td>
+            <td>betsu nonburu<br/>べつのんぶる</td>
+            <td>
               <p its-locale-filter-list="en" lang="en">To number the pages of the front matter, the text and the back matter independently. (JIS Z 8125)</p>
               <p its-locale-filter-list="ja" lang="ja">前付ページ又は後付ページと本文ページとに別の順序付けを行うノンブルを付けること．（JIS Z 8125）</p>
             </td>
           </tr>
           <tr id="term.index">
-            <td class="xfq-term">index</td>
-            <td class="xfq-ja">索引</td>
-            <td class="xfq-transliteration">sakuin<br/>さくいん</td>
-            <td class="xfq-def">
+            <td>index</td>
+            <td>索引</td>
+            <td>sakuin<br/>さくいん</td>
+            <td>
               <p its-locale-filter-list="en" lang="en">A list of terms or subjects with page numbers for where they are referred to in a single or multiple volumes of a book. (JIS Z 8125)</p>
               <p its-locale-filter-list="ja" lang="ja">1冊又は複数冊からなる本の中の語句，事項などを抜き出して配列し，それぞれの該当ページ番号を示したもの．（JIS Z 8125）</p>
             </td>
           </tr>
           <tr id="term.inline-direction">
-            <td class="xfq-term">inline direction</td>
-            <td class="xfq-ja">字詰め方向</td>
-            <td class="xfq-transliteration">jizume hōkō<br/>じづめほうこう</td>
-            <td class="xfq-def">
+            <td>inline direction</td>
+            <td>字詰め方向</td>
+            <td>jizume hōkō<br/>じづめほうこう</td>
+            <td>
               <p its-locale-filter-list="en" lang="en">Text direction in a line. (JIS Z 8125)</p>
               <p its-locale-filter-list="ja" lang="ja">1行の中で，1つの文字から次の文字へと続く方向．（JIS Z 8125）</p>
             </td>
           </tr>
           <tr id="term.inseparable-characters-rule">
-            <td class="xfq-term">inseparable characters rule</td>
-            <td class="xfq-ja">分離禁止</td>
-            <td class="xfq-transliteration">bunri kinshi<br/>ぶんりきんし</td>
-            <td class="xfq-def">
+            <td>inseparable characters rule</td>
+            <td>分離禁止</td>
+            <td>bunri kinshi<br/>ぶんりきんし</td>
+            <td>
               <p its-locale-filter-list="en" lang="en">A line adjustment rule that prohibits inserting any space between specific combinations of characters. (JIS Z 8125)</p>
               <p its-locale-filter-list="ja" lang="ja">特定の文字の組の文字間にアキを入れることを禁止すること．（JIS Z 8125）</p>
             </td>
           </tr>
           <tr id="term.inter-character-space">
-            <td class="xfq-term">inter-character space</td>
-            <td class="xfq-ja">字間</td>
-            <td class="xfq-transliteration">jikan<br/>じかん</td>
-            <td class="xfq-def">
+            <td>inter-character space</td>
+            <td>字間</td>
+            <td>jikan<br/>じかん</td>
+            <td>
               <p its-locale-filter-list="en" lang="en">Amount of space between two adjacent character frames on the same line.</p>
               <p its-locale-filter-list="ja" lang="ja">同一行の隣接する2つの文字の外枠の間隔．</p>
             </td>
           </tr>
           <tr id="term.itemization">
-            <td class="xfq-term">itemization</td>
-            <td class="xfq-ja">箇条書き</td>
-            <td class="xfq-transliteration">kajō gaki<br/>かじょうがき</td>
-            <td class="xfq-def">
+            <td>itemization</td>
+            <td>箇条書き</td>
+            <td>kajō gaki<br/>かじょうがき</td>
+            <td>
               <p its-locale-filter-list="en" lang="en">To list ordered or unordered items one under the other. (JIS Z 8125)</p>
               <p its-locale-filter-list="ja" lang="ja">順序付き，又は順序を明示することなく項目を列挙すること．（JIS Z 8125）</p>
             </td>
           </tr>
           <tr id="term.japanese-and-western-mixed-text-composition">
-            <td class="xfq-term">Japanese and Western mixed text composition</td>
-            <td class="xfq-ja">和欧文混植</td>
-            <td class="xfq-transliteration">waō konshoku<br/>わおうぶんこんしょく</td>
-            <td class="xfq-def">
+            <td>Japanese and Western mixed text composition</td>
+            <td>和欧文混植</td>
+            <td>waō konshoku<br/>わおうぶんこんしょく</td>
+            <td>
               <p its-locale-filter-list="en" lang="en">To mix Japanese text and Western text in the same composition.</p>
               <p its-locale-filter-list="ja" lang="ja">和文と欧文とを併用して組版すること．</p>
             </td>
           </tr>
           <tr id="term.japanese-characters">
-            <td class="xfq-term">Japanese characters</td>
-            <td class="xfq-ja">和文文字</td>
-            <td class="xfq-transliteration">wabun moji<br/>わぶんもじ</td>
-            <td class="xfq-def">
+            <td>Japanese characters</td>
+            <td>和文文字</td>
+            <td>wabun moji<br/>わぶんもじ</td>
+            <td>
               <p its-locale-filter-list="en" lang="en">Characters used to compose Japanese text.</p>
               <p its-locale-filter-list="ja" lang="ja">日本語の文書に使用する文字．</p>
             </td>
           </tr>
           <tr id="term.japanese-gothic-face">
-            <td class="xfq-term">Japanese gothic face</td>
-            <td class="xfq-ja">ゴシック体</td>
-            <td class="xfq-transliteration">goshikku tai<br/>ごしっくたい</td>
-            <td class="xfq-def">
+            <td>Japanese gothic face</td>
+            <td>ゴシック体</td>
+            <td>goshikku tai<br/>ごしっくたい</td>
+            <td>
               <p its-locale-filter-list="en" lang="en">A Japanese typeface, with strokes almost the same in thickness, and no special ornament on a stroke such as a triangular element commonly seen in the Mincho typeface. Used for text emphasis and/or headings.</p>
               <p its-locale-filter-list="ja" lang="ja">文字の線がほぼ同じ幅を持った和文書体で，明朝体のように三角形のうろこが付いていない．強調する部分や見出しなどに用いる．</p>
             </td>
           </tr>
           <tr id="term.jidori">
-            <td class="xfq-term">jidori</td>
-            <td class="xfq-ja">字取り</td>
-            <td class="xfq-transliteration">jidori<br/>じどり</td>
-            <td class="xfq-def">
+            <td>jidori</td>
+            <td>字取り</td>
+            <td>jidori<br/>じどり</td>
+            <td>
               <p its-locale-filter-list="en" lang="en">A method of aligning a run of text to both edges which is specified by a position to start and the length calculated by a specified number of a given size of characters. (JIS Z 8125)</p>
               <p its-locale-filter-list="ja" lang="ja">使用文字サイズの倍数で指定した長さの両端に文字列の先頭と最後尾をそろえて文字を配置する方法．（JIS Z 8125）</p>
             </td>
           </tr>
           <tr id="term.jouyou-kanji-table">
-            <td class="xfq-term">Jouyou Kanji Table</td>
-            <td class="xfq-ja">常用漢字表</td>
-            <td class="xfq-transliteration">jōyō kanji hyō<br/>じょうようかんじひょう</td>
-            <td class="xfq-def">
+            <td>Jouyou Kanji Table</td>
+            <td>常用漢字表</td>
+            <td>jōyō kanji hyō<br/>じょうようかんじひょう</td>
+            <td>
               <p its-locale-filter-list="en" lang="en">The official list of Kanji characters "for general use in society. such as in legal and official documents, newspapers, magazines, broadcasting and the like". It was established in 1981 as a reference guide for people in composing contemporary Japanese. It listed 1,945 of Kanji characters together with their orthographic shapes, Japanese native reading (Kun), Chinese derived reading (On) and other useful information.</p>
               <p its-locale-filter-list="ja" lang="ja">1981年に制定された一般の社会生活において，現代の国語を書き表す場合の漢字使用の目安を示す表．1945字の漢字，その音訓，字体などが示されている．</p>
             </td>
           </tr>
           <tr id="term.jukugo-ruby">
-            <td class="xfq-term">jukugo-ruby</td>
-            <td class="xfq-ja">熟語ルビ</td>
-            <td class="xfq-transliteration">jukugo rubi<br/>じゅくごるび</td>
-            <td class="xfq-def">
+            <td>jukugo-ruby</td>
+            <td>熟語ルビ</td>
+            <td>jukugo rubi<br/>じゅくごるび</td>
+            <td>
               <p its-locale-filter-list="en" lang="en">A method of ruby character distribution determined by two functions, one is to provide reading for each Kanji character, the other is to give a united appearance attached to a word.</p>
               <p its-locale-filter-list="ja" lang="ja">熟語の個々の漢字の読みと熟語としてのまとまりの2つを考慮して配置位置を決めるルビの配置方法．</p>
             </td>
           </tr>
           <tr id="term.kabe">
-            <td class="xfq-term">kabe</td>
-            <td class="xfq-ja">かべ</td>
-            <td class="xfq-transliteration">kabe<br/>かべ</td>
-            <td class="xfq-def">
+            <td>kabe</td>
+            <td>かべ</td>
+            <td>kabe<br/>かべ</td>
+            <td>
               <p its-locale-filter-list="en" lang="en">Main text is bounced before the dannuki headings, illustrations, tables, etc., like balls and walls.</p>
               <p its-locale-filter-list="ja" lang="ja">段組において，版面の中に配置した段抜きの見出し・図版・表組などを壁にたとえ，その手前で文章の行の流れを折り返すこと．</p>
             </td>
           </tr>
           <tr id="term.kanbun-composition">
-            <td class="xfq-term">kanbun composition</td>
-            <td class="xfq-ja">漢文</td>
-            <td class="xfq-transliteration">kanbun<br/>かんぶん</td>
-            <td class="xfq-def">
+            <td>kanbun composition</td>
+            <td>漢文</td>
+            <td>kanbun<br/>かんぶん</td>
+            <td>
               <p its-locale-filter-list="en" lang="en">Chinese classic text (or  text in the same style) with various auxiliary symbols so that it can be read as Japanese text.</p>
               <p its-locale-filter-list="ja" lang="ja">中国の古典文（又はそれにならった文体の文）について，日本語の文として読むことが可能になるように，読むための様々な補助記号を付けた文．</p>
             </td>
           </tr>
           <tr id="term.katatsuki">
-            <td class="xfq-term">katatsuki (katatsuki-ruby)</td>
-            <td class="xfq-ja">肩付き（肩付きルビ）</td>
-            <td class="xfq-transliteration">katatsuki (katatsuki rubi)<br/>かたつき</td>
-            <td class="xfq-def">
+            <td>katatsuki (katatsuki-ruby)</td>
+            <td>肩付き（肩付きルビ）</td>
+            <td>katatsuki (katatsuki rubi)<br/>かたつき</td>
+            <td>
               <p its-locale-filter-list="en" lang="en">A method of attaching ruby at the upper right of each base character. (JIS Z 8125)</p>
               <p its-locale-filter-list="ja" lang="ja">縦組において，ルビを親文字の右肩に付けて配置する方法．（JIS Z 8125）</p>
             </td>
           </tr>
           <tr id="term.kihon-hanmen">
-            <td class="xfq-term">kihon-hanmen</td>
-            <td class="xfq-ja">基本版面</td>
-            <td class="xfq-transliteration">kihon hanmen<br/>きほんはんめん</td>
-            <td class="xfq-def">
+            <td>kihon-hanmen</td>
+            <td>基本版面</td>
+            <td>kihon hanmen<br/>きほんはんめん</td>
+            <td>
               <p its-locale-filter-list="en" lang="en">The default dimensions of the main area of a typeset page specified by text direction, number of columns, character size, number of characters in a line, number of lines in a column, inter-line spacing and inter-column spacing. (JIS X 4051)</p>
               <p its-locale-filter-list="ja" lang="ja">本の基本として設計される版面体裁．組方向，段数，文字サイズ，字詰め数，行数，行間及び段間で指定する．（JIS X 4051）</p>
             </td>
           </tr>
           <tr id="term.label-name">
-            <td class="xfq-term">label name</td>
-            <td class="xfq-ja">ラベル名</td>
-            <td class="xfq-transliteration">raberumei<br/>らべるめい</td>
-            <td class="xfq-def">
+            <td>label name</td>
+            <td>ラベル名</td>
+            <td>raberumei<br/>らべるめい</td>
+            <td>
               <p its-locale-filter-list="en" lang="en">Text following or followed by numbers for illustrations, tables, headings and running headings. (JIS X 4051)</p>
               <p its-locale-filter-list="ja" lang="ja">図番号，表番号，見出し番号及び柱番号において，それぞれの番号の前及び／又は後ろに付ける文字列．（JIS X 4051）</p>
             </td>
           </tr>
           <tr id="term.letter-face">
-            <td class="xfq-term">letter face</td>
-            <td class="xfq-ja">字面</td>
-            <td class="xfq-transliteration">jizura<br/>じづら</td>
-            <td class="xfq-def">
+            <td>letter face</td>
+            <td>字面</td>
+            <td>jizura<br/>じづら</td>
+            <td>
               <p its-locale-filter-list="en" lang="en">Area in which glyph is drawn. (JIS Z 8125)</p>
               <p its-locale-filter-list="ja" lang="ja">字形の，実際に表示される領域．（JIS Z 8125）</p>
             </td>
           </tr>
           <tr id="term.letterpress-printing">
-            <td class="xfq-term">letterpress printing</td>
-            <td class="xfq-ja">活字組版</td>
-            <td class="xfq-transliteration">katsuji kumihan<br/>かつじくみはん</td>
-            <td class="xfq-def">
+            <td>letterpress printing</td>
+            <td>活字組版</td>
+            <td>katsuji kumihan<br/>かつじくみはん</td>
+            <td>
               <p its-locale-filter-list="en" lang="en">The traditional printing method using movable type.</p>
               <p its-locale-filter-list="ja" lang="ja">可動式の活字，その他の材料を用いた伝統的な組版．</p>
             </td>
           </tr>
           <tr id="term.line-adjustment">
-            <td class="xfq-term">line adjustment</td>
-            <td class="xfq-ja">行の調整処理</td>
-            <td class="xfq-transliteration">gyō no chōsei shori<br/>ぎょうのちょうせいしょり</td>
-            <td class="xfq-def">
+            <td>line adjustment</td>
+            <td>行の調整処理</td>
+            <td>gyō no chōsei shori<br/>ぎょうのちょうせいしょり</td>
+            <td>
               <p its-locale-filter-list="en" lang="en">A method of aligning both edges of all lines to be the same given length by removing or adding adjustable spaces.</p>
               <p its-locale-filter-list="ja" lang="ja">指定された行長にするために，字間を詰める又は空ける処理．</p>
             </td>
           </tr>
           <tr id="term.line-adjustment-by-hanging-punctuation">
-            <td class="xfq-term">line adjustment by hanging punctuation</td>
-            <td class="xfq-ja">ぶら下げ組</td>
-            <td class="xfq-transliteration">burasage gumi<br/>ぶらさげぐみ</td>
-            <td class="xfq-def">
+            <td>line adjustment by hanging punctuation</td>
+            <td>ぶら下げ組</td>
+            <td>burasage gumi<br/>ぶらさげぐみ</td>
+            <td>
               <p its-locale-filter-list="en" lang="en">A line breaking rule to avoid commas or full stops at a line head (which is prohibited in Japanese typography) by taking them back to the end of the previous line beyond the specified line length. (JIS Z 8125)</p>
               <p its-locale-filter-list="ja" lang="ja">行頭に位置した和文の句読点を1文字だけ前行の行末文字の次に指定された行長を越えて配置する方法．（JIS Z 8125）</p>
             </td>
           </tr>
           <tr id="term.line-adjustment-by-inter-character-space-expansion">
-            <td class="xfq-term">line adjustment by inter-character space expansion</td>
-            <td class="xfq-ja">追出し処理</td>
-            <td class="xfq-transliteration">oidashi shori<br/>おいだししょり</td>
-            <td class="xfq-def">
+            <td>line adjustment by inter-character space expansion</td>
+            <td>追出し処理</td>
+            <td>oidashi shori<br/>おいだししょり</td>
+            <td>
               <p its-locale-filter-list="en" lang="en">A line breaking rule that aligns both edges of a line by expanding inter-character spaces. (JIS Z 8125).</p>
               <p its-locale-filter-list="ja" lang="ja">禁則処理の1つの方法であって，字間を広げて行頭行末そろえをすること（JIS Z 8125）．行頭行末そろえとは，各行の最初の文字を行頭にそろえ，かつ各行の最後の文字を行末にそろえて配置する方法（JIS Z 8125）．</p>
             </td>
           </tr>
           <tr id="term.line-adjustment-by-inter-character-space-reduction">
-            <td class="xfq-term">line adjustment by inter-character space reduction</td>
-            <td class="xfq-ja">追込み処理</td>
-            <td class="xfq-transliteration">oikomi shori<br/>おいこみしょり</td>
-            <td class="xfq-def">
+            <td>line adjustment by inter-character space reduction</td>
+            <td>追込み処理</td>
+            <td>oikomi shori<br/>おいこみしょり</td>
+            <td>
               <p its-locale-filter-list="en" lang="en">A line breaking rule that aligns both edges of a line by removing adjustable spaces such as conditional spaces for punctuation marks. (JIS Z 8125).</p>
               <p its-locale-filter-list="ja" lang="ja">禁則処理の1つの方法であって，約物の前後などを詰めて行頭行末そろえをすること（JIS Z 8125）．行頭行末そろえとは，各行の最初の文字を行頭にそろえ，かつ各行の最後の文字を行末にそろえて配置する方法（JIS Z 8125）．</p>
             </td>
           </tr>
           <tr id="term.line-breaking-rules">
-            <td class="xfq-term">line breaking rules</td>
-            <td class="xfq-ja">禁則処理</td>
-            <td class="xfq-transliteration">kinsoku shori<br/>きんそくしょり</td>
-            <td class="xfq-def">
+            <td>line breaking rules</td>
+            <td>禁則処理</td>
+            <td>kinsoku shori<br/>きんそくしょり</td>
+            <td>
               <p its-locale-filter-list="en" lang="en">A set of rules to avoid prohibited layout in Japanese typography, such as "line-start prohibition rule", "line-end prohibition rule", inseparable or unbreakable character sequences and so on. (JIS Z 8125)</p>
               <p its-locale-filter-list="ja" lang="ja">行頭禁則，行末禁則，分離（分割）禁止などの禁則を避けるために行われる処理．（JIS Z 8125）</p>
             </td>
           </tr>
           <tr id="term.line-end">
-            <td class="xfq-term">line end</td>
-            <td class="xfq-ja">行末</td>
-            <td class="xfq-transliteration">gyōmatsu<br/>ぎょうまつ</td>
-            <td class="xfq-def">
+            <td>line end</td>
+            <td>行末</td>
+            <td>gyōmatsu<br/>ぎょうまつ</td>
+            <td>
               <p its-locale-filter-list="en" lang="en">The position at which a line ends. (JIS Z 8125)</p>
               <p its-locale-filter-list="ja" lang="ja">1つの行の終わる位置．（JIS Z 8125）</p>
             </td>
           </tr>
           <tr id="term.line-end-alignment">
-            <td class="xfq-term">line end alignment</td>
-            <td class="xfq-ja">行末そろえ</td>
-            <td class="xfq-transliteration">gyōmatsu soroe<br/>ぎょうまつそろえ</td>
-            <td class="xfq-def">
+            <td>line end alignment</td>
+            <td>行末そろえ</td>
+            <td>gyōmatsu soroe<br/>ぎょうまつそろえ</td>
+            <td>
               <p its-locale-filter-list="en" lang="en">To align a run of text to the line end. (JIS Z 8125)</p>
               <p its-locale-filter-list="ja" lang="ja">文字列の最後の文字を行末の位置に合わせること．（JIS Z 8125）</p>
             </td>
           </tr>
           <tr id="term.line-end-indent">
-            <td class="xfq-term">line end indent</td>
-            <td class="xfq-ja">字上げ</td>
-            <td class="xfq-transliteration">jiage<br/>じあげ</td>
-            <td class="xfq-def">
+            <td>line end indent</td>
+            <td>字上げ</td>
+            <td>jiage<br/>じあげ</td>
+            <td>
               <p its-locale-filter-list="en" lang="en">To reserve a certain amount of space before the default position of a line end. (JIS Z 8125)</p>
               <p its-locale-filter-list="ja" lang="ja">行末の位置を行頭方向に移すこと．（JIS Z 8125）</p>
             </td>
           </tr>
           <tr id="term.line-feed">
-            <td class="xfq-term">line feed</td>
-            <td class="xfq-ja">行送り</td>
-            <td class="xfq-transliteration">gyō okuri<br/>ぎょうおくり</td>
-            <td class="xfq-def">
+            <td>line feed</td>
+            <td>行送り</td>
+            <td>gyō okuri<br/>ぎょうおくり</td>
+            <td>
               <p its-locale-filter-list="en" lang="en">The distance between two adjacent lines measured by their reference points. (JIS Z 8125)</p>
               <p its-locale-filter-list="ja" lang="ja">隣接する行同士の基準点から基準点までの距離．（JIS Z 8125）</p>
             </td>
           </tr>
           <tr id="term.line-gap">
-            <td class="xfq-term">line gap</td>
-            <td class="xfq-ja">行間</td>
-            <td class="xfq-transliteration">gyōkan<br/>ぎょうかん</td>
-            <td class="xfq-def">
+            <td>line gap</td>
+            <td>行間</td>
+            <td>gyōkan<br/>ぎょうかん</td>
+            <td>
               <p its-locale-filter-list="en" lang="en">The smallest amount of space between adjacent lines.</p>
               <p its-locale-filter-list="ja" lang="ja">隣接する行の文字の外枠間の距離．</p>
             </td>
           </tr>
           <tr id="term.line-head">
-            <td class="xfq-term">line head</td>
-            <td class="xfq-ja">行頭</td>
-            <td class="xfq-transliteration">gyōtō<br/>ぎょうとう</td>
-            <td class="xfq-def">
+            <td>line head</td>
+            <td>行頭</td>
+            <td>gyōtō<br/>ぎょうとう</td>
+            <td>
               <p its-locale-filter-list="en" lang="en">The  position at which a line starts. (JIS Z 8125)</p>
               <p its-locale-filter-list="ja" lang="ja">1つの行の始まる位置．（JIS Z 8125）</p>
             </td>
           </tr>
           <tr id="term.line-head-alignment">
-            <td class="xfq-term">line head alignment</td>
-            <td class="xfq-ja">行頭そろえ</td>
-            <td class="xfq-transliteration">gyōtō soroe<br/>ぎょうとうそろえ</td>
-            <td class="xfq-def">
+            <td>line head alignment</td>
+            <td>行頭そろえ</td>
+            <td>gyōtō soroe<br/>ぎょうとうそろえ</td>
+            <td>
               <p its-locale-filter-list="en" lang="en">To align a run of text to the line head. (JIS Z 8125)</p>
               <p its-locale-filter-list="ja" lang="ja">文字列の最初の文字を行頭の位置に合わせること．（JIS Z 8125）</p>
             </td>
           </tr>
           <tr id="term.line-head-indent">
-            <td class="xfq-term">line head indent</td>
-            <td class="xfq-ja">字下げ</td>
-            <td class="xfq-transliteration">jisage<br/>じさげ</td>
-            <td class="xfq-def">
+            <td>line head indent</td>
+            <td>字下げ</td>
+            <td>jisage<br/>じさげ</td>
+            <td>
               <p its-locale-filter-list="en" lang="en">To reserve a certain amount of space after the default position of a line head. (JIS Z 8125)</p>
               <p its-locale-filter-list="ja" lang="ja">行頭の位置を行末方向に移すこと．（JIS Z 8125）</p>
             </td>
           </tr>
           <tr id="term.line-length">
-            <td class="xfq-term">line length</td>
-            <td class="xfq-ja">行長</td>
-            <td class="xfq-transliteration">gyōchō<br/>ぎょうちょう</td>
-            <td class="xfq-def">
+            <td>line length</td>
+            <td>行長</td>
+            <td>gyōchō<br/>ぎょうちょう</td>
+            <td>
               <p its-locale-filter-list="en" lang="en">Length of a line with a pre-defined number of characters. When the line is indented at the line head or the line end, it is length of the line from the specified amount of line head indent to the specified amount of line end indent.</p>
               <p its-locale-filter-list="ja" lang="ja">基本版面で設定した行の行頭から行末までの長さ．字下げ又は字上げした場合は，指定された行頭から行末までの長さ．</p>
             </td>
           </tr>
           <tr id="term.line-end-prohibition-rule">
-            <td class="xfq-term">line-end prohibition rule</td>
-            <td class="xfq-ja">行末禁則</td>
-            <td class="xfq-transliteration">gyōmatsu kinsoku<br/>ぎょうまつきんそく</td>
-            <td class="xfq-def">
+            <td>line-end prohibition rule</td>
+            <td>行末禁則</td>
+            <td>gyōmatsu kinsoku<br/>ぎょうまつきんそく</td>
+            <td>
               <p its-locale-filter-list="en" lang="en">A line breaking rule that prohibits specific characters at a line end. (JIS Z 8125)</p>
               <p its-locale-filter-list="ja" lang="ja">行末に特定の文字を置くことを禁止する規則．（JIS Z 8125）</p>
             </td>
           </tr>
           <tr id="term.line-start-prohibition-rule">
-            <td class="xfq-term">line-start prohibition rule</td>
-            <td class="xfq-ja">行頭禁則</td>
-            <td class="xfq-transliteration">gyōtō kinsoku<br/>ぎょうとうきんそく</td>
-            <td class="xfq-def">
+            <td>line-start prohibition rule</td>
+            <td>行頭禁則</td>
+            <td>gyōtō kinsoku<br/>ぎょうとうきんそく</td>
+            <td>
               <p its-locale-filter-list="en" lang="en">A line breaking rule that prohibits specific characters at a line head. (JIS Z 8125)</p>
               <p its-locale-filter-list="ja" lang="ja">行頭に特定の文字を置くことを禁止する規則．（JIS Z 8125）</p>
             </td>
           </tr>
           <tr id="term.main-text">
-            <td class="xfq-term">main text</td>
-            <td class="xfq-ja">本文</td>
-            <td class="xfq-transliteration">honbun<br/>ほんぶん</td>
-            <td class="xfq-def">
+            <td>main text</td>
+            <td>本文</td>
+            <td>honbun<br/>ほんぶん</td>
+            <td>
               <div its-locale-filter-list="en" lang="en">
                   <div>a) The principal part of  a book, usually preceded by the front matter, followed by the back matter.</div>
                   <div>b) The principal part of an article excluding figures, tables, heading, notes, leads and so on.</div>
@@ -23770,38 +23770,38 @@
             </td>
           </tr>
           <tr id="term.matrix">
-            <td class="xfq-term">matrix</td>
-            <td class="xfq-ja">母型</td>
-            <td class="xfq-transliteration">bokei<br/>ぼけい</td>
-            <td class="xfq-def">
+            <td>matrix</td>
+            <td>母型</td>
+            <td>bokei<br/>ぼけい</td>
+            <td>
               <p its-locale-filter-list="en" lang="en">A metal mold from which movable type is cast.</p>
               <p its-locale-filter-list="ja" lang="ja">活字を鋳造する際に，字面を形成する型．</p>
             </td>
           </tr>
           <tr id="term.mawarikomi">
-            <td class="xfq-term">mawarikomi</td>
-            <td class="xfq-ja">回り込み</td>
-            <td class="xfq-transliteration">mawarikomi<br/>まわりこみ</td>
-            <td class="xfq-def">
+            <td>mawarikomi</td>
+            <td>回り込み</td>
+            <td>mawarikomi<br/>まわりこみ</td>
+            <td>
               <p its-locale-filter-list="en" lang="en">Text setting style to fill the left line direction space, which is happen to appear because of the arragnement of illustrations, tables, etc. (JIS Z 8125)</p>
               <p its-locale-filter-list="ja" lang="ja">図版，表組などを配置するために確保した領域の字詰め方向の余白に本文を組み込むこと．（JIS Z 8125）</p>
             </td>
           </tr>
           <tr id="term.mincho-typeface">
-            <td class="xfq-term">Mincho typeface</td>
-            <td class="xfq-ja">明朝体</td>
-            <td class="xfq-transliteration">minchōtai<br/>みんちょうたい</td>
-            <td class="xfq-def">
+            <td>Mincho typeface</td>
+            <td>明朝体</td>
+            <td>minchōtai<br/>みんちょうたい</td>
+            <td>
               <p its-locale-filter-list="en" lang="en">A major style of Japanese font. Horizontal lines are thin and vertical lines are thick. At the start position and the end position, there are triangular figure representing press of brush. Kana are designed to balance the Kanji design. In Japanese text setting, Mincho typeface is most frequently used for main text, especially for long </p>
               <p its-locale-filter-list="ja" lang="ja">漢字は，横線に比べて縦線が太く，起筆部と終筆部に三角形が付いている．これに調和するように設計された仮名が作られている．日本語の長文の文書では，最も使用頻度が高い．</p>
               text.
               Similar to "serif" of Western typography.</td>
           </tr>
           <tr id="term.mixed-text-composition">
-            <td class="xfq-term">mixed text composition</td>
-            <td class="xfq-ja">混植</td>
-            <td class="xfq-transliteration">konshoku<br/>こんしょく</td>
-            <td class="xfq-def">
+            <td>mixed text composition</td>
+            <td>混植</td>
+            <td>konshoku<br/>こんしょく</td>
+            <td>
                 <div its-locale-filter-list="en" lang="en">
                     <div>a) To interleave Japanese text with Western text in a line (Japanese and Western mixed text composition).</div>
                     <div> b) To compose text with different sizes of characters (mixed size composition).</div>
@@ -23817,505 +23817,505 @@
             </td>
           </tr>
           <tr id="term.mono-ruby">
-            <td class="xfq-term">mono-ruby</td>
-            <td class="xfq-ja">モノルビ</td>
-            <td class="xfq-transliteration">mono rubi<br/>ものるび</td>
-            <td class="xfq-def">
+            <td>mono-ruby</td>
+            <td>モノルビ</td>
+            <td>mono rubi<br/>ものるび</td>
+            <td>
               <p its-locale-filter-list="en" lang="en">A method of ruby distribution where a run of ruby text is attached to each base character. (JIS Z 8125)</p>
               <p its-locale-filter-list="ja" lang="ja">親文字の1字ごとに対応してルビを付けて配置する方法．（JIS Z 8125）</p>
             </td>
           </tr>
           <tr id="term.multi-column-format">
-            <td class="xfq-term">multi-column format</td>
-            <td class="xfq-ja">段組</td>
-            <td class="xfq-transliteration">dangumi<br/>だんぐみ</td>
-            <td class="xfq-def">
+            <td>multi-column format</td>
+            <td>段組</td>
+            <td>dangumi<br/>だんぐみ</td>
+            <td>
               <p its-locale-filter-list="en" lang="en">A format of text on a page where  text is divided into two or more sections (columns) in the inline direction and each column is separated by a certain amount of space (column space). (JIS Z 8125)</p>
               <p its-locale-filter-list="ja" lang="ja">連続する1系列の文章を1ページの中で，字詰め方向において，2つ以上の部分（段）に分割し，各部分の間には空白（段間）を設けて文字を配置する方法．（JIS Z 8125）</p>
             </td>
           </tr>
           <tr id="term.multivolume-work">
-            <td class="xfq-term">multivolume work</td>
-            <td class="xfq-ja">多巻物</td>
-            <td class="xfq-transliteration">takanmono<br/>たかんもの</td>
-            <td class="xfq-def">
+            <td>multivolume work</td>
+            <td>多巻物</td>
+            <td>takanmono<br/>たかんもの</td>
+            <td>
               <p its-locale-filter-list="en" lang="en">A set of work published in two or more volumes, as in the complete work or the first/last half volumes.</p>
               <p its-locale-filter-list="ja" lang="ja">全集，上下巻など，1部の本で2冊以上の図書で構成されているもの．</p>
             </td>
           </tr>
           <tr id="term.naka-tobira">
-            <td class="xfq-term">naka-tobira</td>
-            <td class="xfq-ja">中扉</td>
-            <td class="xfq-transliteration">naka tobira<br/>なかとびら</td>
-            <td class="xfq-def">
+            <td>naka-tobira</td>
+            <td>中扉</td>
+            <td>naka tobira<br/>なかとびら</td>
+            <td>
               <p its-locale-filter-list="en" lang="en">A recto or a page inserted to divide two different parts in a book. It often has a title or other text to describe the new part. (JIS Z 8125)</p>
               <p its-locale-filter-list="ja" lang="ja">書籍の内容が大きく区分される場合に，その内容の区切りをはっきりさせるために本文中に挿入する，標題などを掲げた丁又はページ．（JIS Z 8125）</p>
             </td>
           </tr>
           <tr id="term.nakatsuki">
-            <td class="xfq-term">nakatsuki (nakatsuki-ruby)</td>
-            <td class="xfq-ja">中付き（中付きルビ）</td>
-            <td class="xfq-transliteration">nakatsuki (nakatsuki rubi)<br/>なかつき</td>
-            <td class="xfq-def">
+            <td>nakatsuki (nakatsuki-ruby)</td>
+            <td>中付き（中付きルビ）</td>
+            <td>nakatsuki (nakatsuki rubi)<br/>なかつき</td>
+            <td>
               <p its-locale-filter-list="en" lang="en">A method of ruby character distribution where each ruby character is aligned to the vertical center of the corresponding base character in vertical writing mode, or to the horizontal center of the base character in horizontal writing mode. (JIS Z 8125)</p>
               <p its-locale-filter-list="ja" lang="ja">縦組の場合は親文字の天地中央に，横組の場合は親文字の左右中央にルビを付けて配置する方法．（JIS Z 8125）</p>
             </td>
           </tr>
           <tr id="term.new-column">
-            <td class="xfq-term">new column</td>
-            <td class="xfq-ja">改段</td>
-            <td class="xfq-transliteration">kaidan<br/>かいだん</td>
-            <td class="xfq-def">
+            <td>new column</td>
+            <td>改段</td>
+            <td>kaidan<br/>かいだん</td>
+            <td>
               <p its-locale-filter-list="en" lang="en">In multi-column setting, to change to new column before the end of current column.</p>
               <p its-locale-filter-list="ja" lang="ja">段組で段の途中にもかかわらず，次の見出しなどを新しい段の始めから配置すること．</p>
             </td>
           </tr>
           <tr id="term.new-recto">
-            <td class="xfq-term">new recto</td>
-            <td class="xfq-ja">改丁</td>
-            <td class="xfq-transliteration">kaichō<br/>かいちょう</td>
-            <td class="xfq-def">
+            <td>new recto</td>
+            <td>改丁</td>
+            <td>kaichō<br/>かいちょう</td>
+            <td>
               <p its-locale-filter-list="en" lang="en">To start a new heading or something on a odd page. (JIS Z 8125)</p>
               <p its-locale-filter-list="ja" lang="ja">奇数ページより新規に見出しなどを始めること．（JIS Z 8125）</p>
             </td>
           </tr>
           <tr id="term.note">
-            <td class="xfq-term">note</td>
-            <td class="xfq-ja">注</td>
-            <td class="xfq-transliteration">chū<br/>ちゅう</td>
-            <td class="xfq-def">
+            <td>note</td>
+            <td>注</td>
+            <td>chū<br/>ちゅう</td>
+            <td>
               <p its-locale-filter-list="en" lang="en">Explanatory information added to terms, figures or tables. (JIS Z 8125)</p>
               <p its-locale-filter-list="ja" lang="ja">語句，図版，表などに加える補助的な説明・解釈．（JIS Z 8125）</p>
             </td>
           </tr>
           <tr id="term.number-of-characters-per-line">
-            <td class="xfq-term">number of characters per line</td>
-            <td class="xfq-ja">字詰め</td>
-            <td class="xfq-transliteration">jizume<br/>じづめ</td>
-            <td class="xfq-def">
+            <td>number of characters per line</td>
+            <td>字詰め</td>
+            <td>jizume<br/>じづめ</td>
+            <td>
               <p its-locale-filter-list="en" lang="en">Number of characters in a line to specify the length of lines. (JIS Z 8125)</p>
               <p its-locale-filter-list="ja" lang="ja">図版，表組などを配置するために確保した領域の字詰め方向の余白に本文を組み込むこと．（JIS Z 8125）</p>
             </td>
           </tr>
           <tr id="term.number-of-columns">
-            <td class="xfq-term">number of columns</td>
-            <td class="xfq-ja">段数</td>
-            <td class="xfq-transliteration">dansū<br/>だんすう</td>
-            <td class="xfq-def">
+            <td>number of columns</td>
+            <td>段数</td>
+            <td>dansū<br/>だんすう</td>
+            <td>
               <p its-locale-filter-list="en" lang="en">Number of columns on a page. (JIS Z 8125)</p>
               <p its-locale-filter-list="ja" lang="ja">1ページ内に配置される段の数．（JIS Z 8125）</p>
             </td>
           </tr>
           <tr id="term.omote-kei">
-            <td class="xfq-term">omote-kei</td>
-            <td class="xfq-ja">表罫</td>
-            <td class="xfq-transliteration">omotekei<br/>おもてけい</td>
-            <td class="xfq-def">
+            <td>omote-kei</td>
+            <td>表罫</td>
+            <td>omotekei<br/>おもてけい</td>
+            <td>
               <p its-locale-filter-list="en" lang="en">Thin width line. Usually about 0.12mm. (JIS Z 8125)</p>
               <p its-locale-filter-list="ja" lang="ja">0.1mm程度の太さの実線．（JIS Z 8125）</p>
             </td>
           </tr>
           <tr id="term.one-em-space">
-            <td class="xfq-term">one em space</td>
-            <td class="xfq-ja">全角アキ</td>
-            <td class="xfq-transliteration">zenkaku aki<br/>ぜんかくあき</td>
-            <td class="xfq-def">
+            <td>one em space</td>
+            <td>全角アキ</td>
+            <td>zenkaku aki<br/>ぜんかくあき</td>
+            <td>
               <p its-locale-filter-list="en" lang="en">Amount of space that is full-width size.</p>
               <p its-locale-filter-list="ja" lang="ja">全角の空き量．</p>
             </td>
           </tr>
           <tr id="term.one-third-em">
-            <td class="xfq-term">one third em</td>
-            <td class="xfq-ja">三分</td>
-            <td class="xfq-transliteration">sanbu<br/>さんぶ</td>
-            <td class="xfq-def">
+            <td>one third em</td>
+            <td>三分</td>
+            <td>sanbu<br/>さんぶ</td>
+            <td>
               <p its-locale-filter-list="en" lang="en">One third of the full-width size. (JIS Z 8125)</p>
               <p its-locale-filter-list="ja" lang="ja">全角の3分の1の長さ．（JIS Z 8125）</p>
             </td>
           </tr>
           <tr id="term.one-third-em-space">
-            <td class="xfq-term">one third em space</td>
-            <td class="xfq-ja">三分アキ</td>
-            <td class="xfq-transliteration">sanbu aki<br/>さんぶあき</td>
-            <td class="xfq-def">
+            <td>one third em space</td>
+            <td>三分アキ</td>
+            <td>sanbu aki<br/>さんぶあき</td>
+            <td>
               <p its-locale-filter-list="en" lang="en">Amount of space that is one third size of em space.</p>
               <p its-locale-filter-list="ja" lang="ja">三分の空き量．</p>
             </td>
           </tr>
           <tr id="term.one-third-ruby">
-            <td class="xfq-term">one-third-ruby</td>
-            <td class="xfq-ja">三分ルビ</td>
-            <td class="xfq-transliteration">sanbu rubi<br/>さんぶるび</td>
-            <td class="xfq-def">
+            <td>one-third-ruby</td>
+            <td>三分ルビ</td>
+            <td>sanbu rubi<br/>さんぶるび</td>
+            <td>
               <p its-locale-filter-list="en" lang="en">Ruby characters, narrow enough so that three can fit within the width of a full-width base character.</p>
               <p its-locale-filter-list="ja" lang="ja">全角の字幅の親文字1字に対し，3文字のルビを親文字からはみ出させないように付けるためのルビ．</p>
             </td>
           </tr>
           <tr id="term.original-pattern">
-            <td class="xfq-term">original pattern</td>
-            <td class="xfq-ja">原図</td>
-            <td class="xfq-transliteration">genzu<br/>げんず</td>
-            <td class="xfq-def">
+            <td>original pattern</td>
+            <td>原図</td>
+            <td>genzu<br/>げんず</td>
+            <td>
               <p its-locale-filter-list="en" lang="en">An original drawn pattern of a character image to be used for a printing type or a digitized glyph.</p>
               <p its-locale-filter-list="ja" lang="ja">印刷用の文字の元となる描かれた文字．</p>
             </td>
           </tr>
           <tr id="term.ornament-characters">
-            <td class="xfq-term">ornament characters</td>
-            <td class="xfq-ja">添え字</td>
-            <td class="xfq-transliteration">soeji<br/>そえじ</td>
-            <td class="xfq-def">
+            <td>ornament characters</td>
+            <td>添え字</td>
+            <td>soeji<br/>そえじ</td>
+            <td>
               <p its-locale-filter-list="en" lang="en">A superscript or subscript attached to a base character. (JIS Z 8125)</p>
               <p its-locale-filter-list="ja" lang="ja">文字のそばに付ける上付き文字又は下付き文字．（JIS Z 8125）</p>
             </td>
           </tr>
           <tr id="term.page">
-            <td class="xfq-term">page</td>
-            <td class="xfq-ja">ページ</td>
-            <td class="xfq-transliteration">pēji<br/>ぺーじ</td>
-            <td class="xfq-def">
+            <td>page</td>
+            <td>ページ</td>
+            <td>pēji<br/>ぺーじ</td>
+            <td>
               <p its-locale-filter-list="en" lang="en">A side of a sheet of paper in a written work such as a book. (JIS Z 8125)</p>
               <p its-locale-filter-list="ja" lang="ja">本などを構成する1枚の紙の片面．（JIS Z 8125）</p>
             </td>
           </tr>
           <tr id="term.page-break">
-            <td class="xfq-term">page break</td>
-            <td class="xfq-ja">改ページ</td>
-            <td class="xfq-transliteration">kai pēji<br/>かいぺーじ</td>
-            <td class="xfq-def">
+            <td>page break</td>
+            <td>改ページ</td>
+            <td>kai pēji<br/>かいぺーじ</td>
+            <td>
               <p its-locale-filter-list="en" lang="en">To end a page even if it is not full and to start a new page with the next paragraph, a new heading and so on. (JIS Z 8125)</p>
               <p its-locale-filter-list="ja" lang="ja">奇数ページ・偶数ページに関わらず，ページの途中であっても次の文章・見出しなどを次のページから新しく始めること．（JIS Z 8125）</p>
             </td>
           </tr>
           <tr id="term.page-format">
-            <td class="xfq-term">page format</td>
-            <td class="xfq-ja">組体裁</td>
-            <td class="xfq-transliteration">kumi teisai<br/>くみていさい</td>
-            <td class="xfq-def">
+            <td>page format</td>
+            <td>組体裁</td>
+            <td>kumi teisai<br/>くみていさい</td>
+            <td>
               <p its-locale-filter-list="en" lang="en">The layout and presentation of a page with text, graphics and other elements for a publication such as a book.</p>
               <p its-locale-filter-list="ja" lang="ja">本などの仕上りサイズ及びそこに配置する文字その他の表示体裁．</p>
             </td>
           </tr>
           <tr id="term.page-number">
-            <td class="xfq-term">page number</td>
-            <td class="xfq-ja">ノンブル</td>
-            <td class="xfq-transliteration">nonburu<br/>のんぶる</td>
-            <td class="xfq-def">
+            <td>page number</td>
+            <td>ノンブル</td>
+            <td>nonburu<br/>のんぶる</td>
+            <td>
               <p its-locale-filter-list="en" lang="en">A sequential number to indicate the order of pages in a publication. (JIS Z 8125)</p>
               <p its-locale-filter-list="ja" lang="ja">印刷物の各ページの順序を示すために付けてある番号．（JIS Z 8125）</p>
             </td>
           </tr>
           <tr id="term.para-ruby">
-            <td class="xfq-term">para-ruby</td>
-            <td class="xfq-ja">パラルビ</td>
-            <td class="xfq-transliteration">para rubi<br/>ぱらるび</td>
-            <td class="xfq-def">
+            <td>para-ruby</td>
+            <td>パラルビ</td>
+            <td>para rubi<br/>ぱらるび</td>
+            <td>
               <p its-locale-filter-list="en" lang="en">A method of ruby annotation where ruby text is only attached to selected Kanji characters in the text. (JIS Z 8125)</p>
               <p its-locale-filter-list="ja" lang="ja">文中の一部の漢字だけにルビを付けること．（JIS Z 8125）</p>
             </td>
           </tr>
           <tr id="term.paragraph">
-            <td class="xfq-term">paragraph</td>
-            <td class="xfq-ja">段落</td>
-            <td class="xfq-transliteration">danraku<br/>だんらく</td>
-            <td class="xfq-def">
+            <td>paragraph</td>
+            <td>段落</td>
+            <td>danraku<br/>だんらく</td>
+            <td>
               <p its-locale-filter-list="en" lang="en">A group of sentences to be processed for line composition. A paragraph consists of one or more lines. (JIS Z 8125)</p>
               <p its-locale-filter-list="ja" lang="ja">行組版処理の処理単位となる1つ以上の文の集まり．段落は，1行又は連続した複数の行からなる．（JIS Z 8125）</p>
             </td>
           </tr>
           <tr id="term.paragraph-break">
-            <td class="xfq-term">paragraph break</td>
-            <td class="xfq-ja">改行</td>
-            <td class="xfq-transliteration">kaigyō<br/>かいぎょう</td>
-            <td class="xfq-def">
+            <td>paragraph break</td>
+            <td>改行</td>
+            <td>kaigyō<br/>かいぎょう</td>
+            <td>
               <p its-locale-filter-list="en" lang="en">To start a new line to indicate a new paragraph.</p>
               <p its-locale-filter-list="ja" lang="ja">段落の区切りなどを示すために行を改めること．</p>
             </td>
           </tr>
           <tr id="term.paragraph-format">
-            <td class="xfq-term">paragraph format</td>
-            <td class="xfq-ja">段落整形</td>
-            <td class="xfq-transliteration">danraku seikei<br/>だんらくせいけい</td>
-            <td class="xfq-def">
+            <td>paragraph format</td>
+            <td>段落整形</td>
+            <td>danraku seikei<br/>だんらくせいけい</td>
+            <td>
               <p its-locale-filter-list="en" lang="en">A format of a paragraph, as in line head indent or line end indent.</p>
               <p its-locale-filter-list="ja" lang="ja">字下げ，字上げ，インデントなどの段落の書式．</p>
             </td>
           </tr>
           <tr id="term.parallel-note">
-            <td class="xfq-term">parallel-note</td>
-            <td class="xfq-ja">並列注</td>
-            <td class="xfq-transliteration">heiretsuchū<br/>へいれつちゅう</td>
-            <td class="xfq-def">
+            <td>parallel-note</td>
+            <td>並列注</td>
+            <td>heiretsuchū<br/>へいれつちゅう</td>
+            <td>
               <p its-locale-filter-list="en" lang="en">Areas of notes are kept when the kihon-hanmen is designed. Related notes are set in these areas, with page unit or spread unit. Parallel-note is the general name for head note (in vertical writing mode), foot note (in vertical writing mode) and side note (in horizontal writing mode).</p>
               <p its-locale-filter-list="ja" lang="ja">基本版面の設計段階であらかじめ注のための領域を確保し，その領域にページ又は見開きを単位として，その範囲にある項目に関連した注を掲げる頭注（縦組），脚注（縦組）及び傍注（横組）の総称．</p>
             </td>
           </tr>
           <tr id="term.point">
-            <td class="xfq-term">point</td>
-            <td class="xfq-ja">ポイント</td>
-            <td class="xfq-transliteration">pointo<br/>ぽいんと</td>
-            <td class="xfq-def">
+            <td>point</td>
+            <td>ポイント</td>
+            <td>pointo<br/>ぽいんと</td>
+            <td>
               <p its-locale-filter-list="en" lang="en">A measurement unit of character size. 1 point is equal to 0.3514mm (see JIS Z 8305). There is another unit to measure character sizes called Q, where 1Q is equivalent to 0.25mm.</p>
               <p its-locale-filter-list="ja" lang="ja">文字サイズの単位．1ポイントは0.3514mmに等しい（JIS Z 8305）．なお，ポイント以外に，文字サイズの単位に使用されている1Qは，0.25mmである．</p>
             </td>
           </tr>
           <tr id="term.printing-types">
-            <td class="xfq-term">printing types</td>
-            <td class="xfq-ja">活字</td>
-            <td class="xfq-transliteration">katsuji<br/>かつじ</td>
-            <td class="xfq-def">
+            <td>printing types</td>
+            <td>活字</td>
+            <td>katsuji<br/>かつじ</td>
+            <td>
               <p its-locale-filter-list="en" lang="en">Movable type used for letterpress printing.</p>
               <p its-locale-filter-list="ja" lang="ja">文字組版に使用するもので，文字・数字・記号類などの字面を逆向きで凸状に，鉛合金などで鋳造した角柱．</p>
             </td>
           </tr>
           <tr id="term.proportional">
-            <td class="xfq-term">proportional</td>
-            <td class="xfq-ja">プロポーショナル</td>
-            <td class="xfq-transliteration">puropōshonaru<br/>ぷろぽーしょなる</td>
-            <td class="xfq-def">
+            <td>proportional</td>
+            <td>プロポーショナル</td>
+            <td>puropōshonaru<br/>ぷろぽーしょなる</td>
+            <td>
               <p its-locale-filter-list="en" lang="en">A characteristic of a font where  character advance is different per glyph. (JIS Z 8125)</p>
               <p its-locale-filter-list="ja" lang="ja">1つのフォント中で文字の字幅が一定でなく，文字ごとに独立した字幅の値を持っていること．（JIS Z 8125）</p>
             </td>
           </tr>
           <tr id="term.punctuation-marks">
-            <td class="xfq-term">punctuation marks</td>
-            <td class="xfq-ja">約物</td>
-            <td class="xfq-transliteration">yakumono<br/>やくもの</td>
-            <td class="xfq-def">
+            <td>punctuation marks</td>
+            <td>約物</td>
+            <td>yakumono<br/>やくもの</td>
+            <td>
               <p its-locale-filter-list="en" lang="en">A general term referring to the symbols used in text composition to help make the meaning of text clearer, as in commas, full stops, question marks, brackets, diereses and so on. (JIS Z 8125)</p>
               <p its-locale-filter-list="ja" lang="ja">文字組版に使用する記述記号類の総称．備考：句読点・疑問符・括弧・アクセントなど．（JIS Z 8125）</p>
             </td>
           </tr>
           <tr id="term.quarter-em">
-            <td class="xfq-term">quarter em</td>
-            <td class="xfq-ja">四分</td>
-            <td class="xfq-transliteration">shibu<br/>しぶ</td>
-            <td class="xfq-def">
+            <td>quarter em</td>
+            <td>四分</td>
+            <td>shibu<br/>しぶ</td>
+            <td>
               <p its-locale-filter-list="en" lang="en">Quarter size of full-width.</p>
               <p its-locale-filter-list="ja" lang="ja">全角の4分の1の長さ．（JIS Z 8125）</p>
             </td>
           </tr>
           <tr id="term.quarter-em-space">
-            <td class="xfq-term">quarter em space</td>
-            <td class="xfq-ja">四分アキ</td>
-            <td class="xfq-transliteration">shibu aki<br/>しぶあき</td>
-            <td class="xfq-def">
+            <td>quarter em space</td>
+            <td>四分アキ</td>
+            <td>shibu aki<br/>しぶあき</td>
+            <td>
               <p its-locale-filter-list="en" lang="en">Amount of space that is a quarter of an em space in size.</p>
               <p its-locale-filter-list="ja" lang="ja">四分の空き量．</p>
             </td>
           </tr>
           <tr id="term.quarter-em-width">
-            <td class="xfq-term">quarter em width</td>
-            <td class="xfq-ja">四分角</td>
-            <td class="xfq-transliteration">shibu kaku<br/>しぶかく</td>
-            <td class="xfq-def">
+            <td>quarter em width</td>
+            <td>四分角</td>
+            <td>shibu kaku<br/>しぶかく</td>
+            <td>
               <p its-locale-filter-list="en" lang="en">Character frame which has a character advance  of a quarter em. (JIS X 4051)</p>
               <p its-locale-filter-list="ja" lang="ja">字幅が，全角の1/4である文字の外枠．（JIS X 4051）</p>
             </td>
           </tr>
           <tr id="term.quotation">
-            <td class="xfq-term">quotation</td>
-            <td class="xfq-ja">引用文</td>
-            <td class="xfq-transliteration">in-yōbun<br/>いんようぶん</td>
-            <td class="xfq-def">
+            <td>quotation</td>
+            <td>引用文</td>
+            <td>in-yōbun<br/>いんようぶん</td>
+            <td>
               <p its-locale-filter-list="en" lang="en">Excerps from other published works. (JIS Z 8125)</p>
               <p its-locale-filter-list="ja" lang="ja">公表された他の著作物から，その一部を引用して利用するもの．（JIS Z 8125）</p>
             </td>
           </tr>
           <tr id="term.reference-marks">
-            <td class="xfq-term">reference marks</td>
-            <td class="xfq-ja">合印</td>
-            <td class="xfq-transliteration">aijirushi<br/>あいじるし</td>
-            <td class="xfq-def">
+            <td>reference marks</td>
+            <td>合印</td>
+            <td>aijirushi<br/>あいじるし</td>
+            <td>
               <p its-locale-filter-list="en" lang="en">A symbol or short run of text attached to a specific part of text, to which notes are provided followed by the corresponding marks.</p>
               <p its-locale-filter-list="ja" lang="ja">注と本文文字列などの該当項目とを対応させるために該当項目に付ける文字列．</p>
             </td>
           </tr>
           <tr id="term.reverse-pagination">
-            <td class="xfq-term">reverse pagination</td>
-            <td class="xfq-ja">逆ノンブル</td>
-            <td class="xfq-transliteration">gyaku nonburu<br/>ぎゃくのんぶる</td>
-            <td class="xfq-def">
+            <td>reverse pagination</td>
+            <td>逆ノンブル</td>
+            <td>gyaku nonburu<br/>ぎゃくのんぶる</td>
+            <td>
               <p its-locale-filter-list="en" lang="en">Numbering pages of a book backwards. (JIS Z 8125)</p>
               <p its-locale-filter-list="ja" lang="ja">巻末の方からページの番号を開始するノンブル．（JIS Z 8125）</p>
             </td>
           </tr>
           <tr id="term.roman-numerals">
-            <td class="xfq-term">Roman numerals</td>
-            <td class="xfq-ja">ローマ数字</td>
-            <td class="xfq-transliteration">rōma sūji<br/>ろーますうじ</td>
-            <td class="xfq-def">
+            <td>Roman numerals</td>
+            <td>ローマ数字</td>
+            <td>rōma sūji<br/>ろーますうじ</td>
+            <td>
               <p its-locale-filter-list="en" lang="en">Numerals represented by upper case or lower case of Latin letters. (JIS Z 8125)</p>
               <p its-locale-filter-list="ja" lang="ja">ラテン文字の大文字又は小文字を用いて表記する数字．（JIS Z 8125）</p>
             </td>
           </tr>
           <tr id="term.ruby">
-            <td class="xfq-term">ruby</td>
-            <td class="xfq-ja">ルビ</td>
-            <td class="xfq-transliteration">rubi<br/>るび</td>
-            <td class="xfq-def">
+            <td>ruby</td>
+            <td>ルビ</td>
+            <td>rubi<br/>るび</td>
+            <td>
               <p its-locale-filter-list="en" lang="en">Supplementary small characters indicating pronunciation, meaning, etc. for the character or the block of characters they annotate. (JIS Z 8125) (Sometimes these annotations are referred to as "furigana".)</p>
               <p its-locale-filter-list="ja" lang="ja">文字及び語のそばに付けて，その読み，意味などを示す小さな文字．（JIS Z 8125）“振り仮名”ともよばれることがある．</p>
             </td>
           </tr>
           <tr id="term.run-in-heading">
-            <td class="xfq-term">run-in heading</td>
-            <td class="xfq-ja">同行見出し</td>
-            <td class="xfq-transliteration">dōgyōmidashi<br/>どうぎょうみだし</td>
-            <td class="xfq-def">
+            <td>run-in heading</td>
+            <td>同行見出し</td>
+            <td>dōgyōmidashi<br/>どうぎょうみだし</td>
+            <td>
               <p its-locale-filter-list="en" lang="en">A kind of heading style to continue main text just after the heading without line break.</p>
               <p its-locale-filter-list="ja" lang="ja">見出しに続く文章を改行することなく，見出しに続けて文章を配置する形式の見出し．</p>
             </td>
           </tr>
           <tr id="term.running-head">
-            <td class="xfq-term">running head</td>
-            <td class="xfq-ja">柱</td>
-            <td class="xfq-transliteration">hashira<br/>はしら</td>
-            <td class="xfq-def">
+            <td>running head</td>
+            <td>柱</td>
+            <td>hashira<br/>はしら</td>
+            <td>
               <p its-locale-filter-list="en" lang="en">A page element which contains information on the title of the book, chapter, section and so on, printed outside the area of the hanmen. (JIS Z 8125)</p>
               <p its-locale-filter-list="ja" lang="ja">各ページの版面外に記載された書名・章名・節名など．（JIS Z 8125）</p>
             </td>
           </tr>
           <tr id="term.second-level-heading">
-            <td class="xfq-term">second level heading</td>
-            <td class="xfq-ja">中見出し</td>
-            <td class="xfq-transliteration">nakamidashi<br/>なかみだし</td>
-            <td class="xfq-def">
+            <td>second level heading</td>
+            <td>中見出し</td>
+            <td>nakamidashi<br/>なかみだし</td>
+            <td>
               <p its-locale-filter-list="en" lang="en">Second level and middle size heading between first level heading and third level heading. (JIS Z 8125)</p>
               <p its-locale-filter-list="ja" lang="ja">大見出しと小見出しとの中間の区分に付ける標題．（JIS Z 8125）</p>
             </td>
           </tr>
           <tr id="term.sidenote">
-            <td class="xfq-term">sidenote</td>
-            <td class="xfq-ja">傍注</td>
-            <td class="xfq-transliteration">bōchū<br/>ぼうちゅう</td>
-            <td class="xfq-def">
+            <td>sidenote</td>
+            <td>傍注</td>
+            <td>bōchū<br/>ぼうちゅう</td>
+            <td>
               <p its-locale-filter-list="en" lang="en">A kind of notes, in vertical writing mode with spread unit, and related notes are set from the left end of left page with smaller size font than the main text. A kind of notes, in horizontal writing mode, the realm is kept beforhand in right side or fore-edge side of kihon-hanmen, and related notes are set in the realm with smaller size font than main text.</p>
               <p its-locale-filter-list="ja" lang="ja">縦組において，見開きを単位として，そこに関連する注を左ページ（奇数ページ）の左端に本文よりも小さな文字サイズにして掲げる注．横組において，基本版面内の小口側又は右側に注を配置するための領域をあらかじめ設定し，その領域に本文よりも小さな文字サイズにして掲げる注．</p>
             </td>
           </tr>
           <tr id="term.single-line-alignment-method">
-            <td class="xfq-term">single line alignment method</td>
-            <td class="xfq-ja">そろえ</td>
-            <td class="xfq-transliteration">soroe<br/>かたばしらほうしき</td>
-            <td class="xfq-def">
+            <td>single line alignment method</td>
+            <td>そろえ</td>
+            <td>soroe<br/>かたばしらほうしき</td>
+            <td>
               <p its-locale-filter-list="en" lang="en">To align a run of text that is shorter than a given line length to designated positions.</p>
               <p its-locale-filter-list="ja" lang="ja">1行の文字列について，指定した位置に文字の配置位置を合わせること．</p>
             </td>
           </tr>
           <tr id="term.single-running-head-method">
-            <td class="xfq-term">single running head method</td>
-            <td class="xfq-ja">片柱方式</td>
-            <td class="xfq-transliteration">katabashira hōshiki<br/>かたばしらほうしき</td>
-            <td class="xfq-def">
+            <td>single running head method</td>
+            <td>片柱方式</td>
+            <td>katabashira hōshiki<br/>かたばしらほうしき</td>
+            <td>
               <p its-locale-filter-list="en" lang="en">A method that puts running heads only on odd pages. (JIS Z 8125)</p>
               <p its-locale-filter-list="ja" lang="ja">柱を奇数ページだけに掲げること．（JIS Z 8125）</p>
             </td>
           </tr>
           <tr id="term.small-kana">
-            <td class="xfq-term">small kana</td>
-            <td class="xfq-ja">小書きの仮名</td>
-            <td class="xfq-transliteration">kogaki no kana<br/>こがきのかな</td>
-            <td class="xfq-def">
+            <td>small kana</td>
+            <td>小書きの仮名</td>
+            <td>kogaki no kana<br/>こがきのかな</td>
+            <td>
               <p its-locale-filter-list="en" lang="en">Kana with smaller letter faces to be used mainly for representing contracted sounds or prolonged vowels. (JIS Z 8125)</p>
               <p its-locale-filter-list="ja" lang="ja">拗音，促音，外来語などを書き表す場合に用いる，字面を小さくした仮名．捨て仮名，半音ともいう．（JIS Z 8125）</p>
             </td>
           </tr>
           <tr id="term.solid-setting">
-            <td class="xfq-term">solid setting</td>
-            <td class="xfq-ja">ベタ組</td>
-            <td class="xfq-transliteration">beta gumi<br/>べたぐみ</td>
-            <td class="xfq-def">
+            <td>solid setting</td>
+            <td>ベタ組</td>
+            <td>beta gumi<br/>べたぐみ</td>
+            <td>
               <p its-locale-filter-list="en" lang="en">To arrange characters with no inter-character space between adjacent character frames.</p>
               <p its-locale-filter-list="ja" lang="ja">字間を空けずに文字の外枠を接して文字を配置すること．</p>
             </td>
           </tr>
           <tr id="term.space">
-            <td class="xfq-term">space</td>
-            <td class="xfq-ja">アキ</td>
-            <td class="xfq-transliteration">aki<br/>あき</td>
-            <td class="xfq-def">
+            <td>space</td>
+            <td>アキ</td>
+            <td>aki<br/>あき</td>
+            <td>
               <p its-locale-filter-list="en" lang="en">Amount of space between adjacent characters or lines. It also refers to the blank area between the edges of a hanmen or an illustration and text or other hanmen elements.</p>
               <p its-locale-filter-list="ja" lang="ja">隣接する文字又は隣接する行の間隔．また，版面，図版などの端から文字列などの端までの間隔．</p>
             </td>
           </tr>
           <tr id="term.spread">
-            <td class="xfq-term">spread</td>
-            <td class="xfq-ja">見開き</td>
-            <td class="xfq-transliteration">mihiraki<br/>みひらき</td>
-            <td class="xfq-def">
+            <td>spread</td>
+            <td>見開き</td>
+            <td>mihiraki<br/>みひらき</td>
+            <td>
               <p its-locale-filter-list="en" lang="en">Any two facing pages when opening a book and the like. (JIS Z 8125)</p>
               <p its-locale-filter-list="ja" lang="ja">本などを開いたときの両方のページ．（JIS Z 8125）</p>
             </td>
           </tr>
           <tr id="term.subscript">
-            <td class="xfq-term">subscript (inferior)</td>
-            <td class="xfq-ja">下付き</td>
-            <td class="xfq-transliteration">shitatsuki<br/>したつき</td>
-            <td class="xfq-def">
+            <td>subscript (inferior)</td>
+            <td>下付き</td>
+            <td>shitatsuki<br/>したつき</td>
+            <td>
               <p its-locale-filter-list="en" lang="en">Smaller face of characters, attached to the lower right or the lower left of a normal size character. (JIS Z 8125)</p>
               <p its-locale-filter-list="ja" lang="ja">小さい字面の文字で，通常の大きさの文字の右下又は左下に付けて配置する文字．（JIS Z 8125）</p>
             </td>
           </tr>
           <tr id="term.subtitle">
-            <td class="xfq-term">subtitle</td>
-            <td class="xfq-ja">副題</td>
-            <td class="xfq-transliteration">fukudai<br/>ふくだい</td>
-            <td class="xfq-def">
+            <td>subtitle</td>
+            <td>副題</td>
+            <td>fukudai<br/>ふくだい</td>
+            <td>
               <p its-locale-filter-list="en" lang="en">Secondary title for headings, subtile. (JIS X 4051)</p>
               <p its-locale-filter-list="ja" lang="ja">見出しに付ける副次的な標題．サブタイトルともいう．（JIS X 4051）</p>
             </td>
           </tr>
           <tr id="term.superscript">
-            <td class="xfq-term">superscript (superior)</td>
-            <td class="xfq-ja">上付き</td>
-            <td class="xfq-transliteration">uwatsuki<br/>うわつき</td>
-            <td class="xfq-def">
+            <td>superscript (superior)</td>
+            <td>上付き</td>
+            <td>uwatsuki<br/>うわつき</td>
+            <td>
               <p its-locale-filter-list="en" lang="en">Smaller face of characters, attached to the upper right or the upper left of a normal size character. (JIS Z 8125)</p>
               <p its-locale-filter-list="ja" lang="ja">小さい字面の文字で，通常の大きさの文字の右肩又は左肩に付けて配置する文字．（JIS Z 8125）</p>
             </td>
           </tr>
           <tr id="term.tab-setting">
-            <td class="xfq-term">tab setting</td>
-            <td class="xfq-ja">タブ処理</td>
-            <td class="xfq-transliteration">tabu shori<br/>たぶしょり</td>
-            <td class="xfq-def">
+            <td>tab setting</td>
+            <td>タブ処理</td>
+            <td>tabu shori<br/>たぶしょり</td>
+            <td>
               <p its-locale-filter-list="en" lang="en">A method of line composition to align one or more runs of text to  designated positions on a line.</p>
               <p its-locale-filter-list="ja" lang="ja">行において，1つ又は複数の文字列を指定位置に合わせて配置する処理．</p>
             </td>
           </tr>
           <tr id="term.table">
-            <td class="xfq-term">table</td>
-            <td class="xfq-ja">表</td>
-            <td class="xfq-transliteration">hyō<br/>ひょう</td>
-            <td class="xfq-def">
+            <td>table</td>
+            <td>表</td>
+            <td>hyō<br/>ひょう</td>
+            <td>
               <p its-locale-filter-list="en" lang="en">Formatted data consisting of characters or numbers, arranged in cells and sometimes divided by lines, in order to present the data in a way that is easier to understand. (JIS Z 8125)</p>
               <p its-locale-filter-list="ja" lang="ja">文字又は数字を一覧できるように，罫などで区切ったこま（小間）に配列したもの．（JIS Z 8125）</p>
             </td>
           </tr>
           <tr id="term.table-of-contents">
-            <td class="xfq-term">table of contents</td>
-            <td class="xfq-ja">目次</td>
-            <td class="xfq-transliteration">mokuji<br/>もくじ</td>
-            <td class="xfq-def">
+            <td>table of contents</td>
+            <td>目次</td>
+            <td>mokuji<br/>もくじ</td>
+            <td>
               <p its-locale-filter-list="en" lang="en">A list of headings of contents of a book in page order or arranged by subjects, with page numbers on which each section begins. (JIS Z 8125)</p>
               <p its-locale-filter-list="ja" lang="ja">本の内容の見出しを，書かれている順又は分野別に並べて，それぞれの該当ページ番号を示したもの．（JIS Z 8125）</p>
             </td>
           </tr>
           <tr id="term.tate-chu-yoko">
-            <td class="xfq-term">tate-chu-yoko</td>
-            <td class="xfq-ja">縦中横</td>
-            <td class="xfq-transliteration">tate chū yoko<br/>たてちゅうよこ</td>
-            <td class="xfq-def">
+            <td>tate-chu-yoko</td>
+            <td>縦中横</td>
+            <td>tate chū yoko<br/>たてちゅうよこ</td>
+            <td>
               <p its-locale-filter-list="en" lang="en">To typeset a (small) group of characters horizontally within a vertical line of main text.</p>
               <p its-locale-filter-list="ja" lang="ja">縦組の行中で，文字を縦向きのまま横組にすること．</p>
             </td>
           </tr>
           <tr id="term.tentsuki">
-            <td class="xfq-term">tentsuki</td>
-            <td class="xfq-ja">天付き</td>
-            <td class="xfq-transliteration">tentsuki<br/>てんつき</td>
-            <td class="xfq-def">
+            <td>tentsuki</td>
+            <td>天付き</td>
+            <td>tentsuki<br/>てんつき</td>
+            <td>
               <div its-locale-filter-list="en" lang="en">
                   <div>a) To remove conditional space from opening brackets at a line head to align the line head to the ones of the adjacent lines.</div>
                   <div> b) Not to add the default line head indent for the first line of a paragraph so as to align all line heads.</div>
@@ -24329,145 +24329,145 @@
             </td>
           </tr>
           <tr id="term.text-direction">
-            <td class="xfq-term">text direction</td>
-            <td class="xfq-ja">組方向</td>
-            <td class="xfq-transliteration">kumi hōkō<br/>くみほうこう</td>
-            <td class="xfq-def">
+            <td>text direction</td>
+            <td>組方向</td>
+            <td>kumi hōkō<br/>くみほうこう</td>
+            <td>
               <p its-locale-filter-list="en" lang="en">Horizontal setting or vertical setting. (JIS Z 8125)</p>
               <p its-locale-filter-list="ja" lang="ja">横組又は縦組．（JIS Z 8125）</p>
             </td>
           </tr>
           <tr id="term.third-level-heading">
-            <td class="xfq-term">third level heading</td>
-            <td class="xfq-ja">小見出し</td>
-            <td class="xfq-transliteration">komidashi<br/>こみだし</td>
-            <td class="xfq-def">
+            <td>third level heading</td>
+            <td>小見出し</td>
+            <td>komidashi<br/>こみだし</td>
+            <td>
               <p its-locale-filter-list="en" lang="en">Headings for smallest or minimum unit of main text in books.</p>
               <p its-locale-filter-list="ja" lang="ja">書籍などで，区分の最小のまとまりに付ける標題．</p>
             </td>
           </tr>
           <tr id="term.top-level-heading">
-            <td class="xfq-term">top level heading</td>
-            <td class="xfq-ja">大見出し</td>
-            <td class="xfq-transliteration">ōmidashi<br/>おおみだし</td>
-            <td class="xfq-def">
+            <td>top level heading</td>
+            <td>大見出し</td>
+            <td>ōmidashi<br/>おおみだし</td>
+            <td>
               <p its-locale-filter-list="en" lang="en">Headings for largest or muximum unit of main text in books.</p>
               <p its-locale-filter-list="ja" lang="ja">書籍などで，区分の最大のまとまりに付ける標題．</p>
             </td>
           </tr>
           <tr id="term.touyou-kanji-table">
-            <td class="xfq-term">Touyou Kanji Table</td>
-            <td class="xfq-ja">当用漢字表</td>
-            <td class="xfq-transliteration">tōyō kanji hyō<br/>とうようかんじひょう</td>
-            <td class="xfq-def">
+            <td>Touyou Kanji Table</td>
+            <td>当用漢字表</td>
+            <td>tōyō kanji hyō<br/>とうようかんじひょう</td>
+            <td>
               <p its-locale-filter-list="en" lang="en">The official list of Kanji characters established in 1946, which was designed to restrict the Kanji characters for general use in society to only those 1850 specified in the list. The list together with other related tables was superseded by the Jouyou Kanji Table.</p>
               <p its-locale-filter-list="ja" lang="ja">1946年に制定された一般社会で使用する漢字の範囲を示す表．1850字の漢字が示されている．この表は，当用漢字音訓表，当用漢字字体表とともに常用漢字表に改められた．</p>
             </td>
           </tr>
           <tr id="term.trim-size">
-            <td class="xfq-term">trim size</td>
-            <td class="xfq-ja">仕上りサイズ</td>
-            <td class="xfq-transliteration">shiagari saizu<br/>しあがりさいず</td>
-            <td class="xfq-def">
+            <td>trim size</td>
+            <td>仕上りサイズ</td>
+            <td>shiagari saizu<br/>しあがりさいず</td>
+            <td>
               <p its-locale-filter-list="en" lang="en">Dimensions of a full page in a publication, including margins. (JIS Z 8125)</p>
               <p its-locale-filter-list="ja" lang="ja">仕上げ裁ちした印刷物の寸法．（JIS Z 8125）</p>
             </td>
           </tr>
           <tr id="term.tsumegumi">
-            <td class="xfq-term">tsumegumi</td>
-            <td class="xfq-ja">詰め組</td>
-            <td class="xfq-transliteration">tsumegumi<br/>つめぐみ</td>
-            <td class="xfq-def">
+            <td>tsumegumi</td>
+            <td>詰め組</td>
+            <td>tsumegumi<br/>つめぐみ</td>
+            <td>
               <p its-locale-filter-list="en" lang="en">Adjustment of inter-character space by making the distance between the letter face of adjacent characters shorter than that produced by solid setting. (JIS Z 8125) </p>
               <p its-locale-filter-list="ja" lang="ja">ベタ組より字送りを詰めて文字を配置する方法（JIS Z 8125）．なお，字送りとは，同一行の隣接する文字同士の基準点から基準点までの距離（JIS Z 8125）．</p>
             </td>
           </tr>
           <tr id="term.type-picking">
-            <td class="xfq-term">type-picking</td>
-            <td class="xfq-ja">文選</td>
-            <td class="xfq-transliteration">bunsen<br/>ぶんせん</td>
-            <td class="xfq-def">
+            <td>type-picking</td>
+            <td>文選</td>
+            <td>bunsen<br/>ぶんせん</td>
+            <td>
               <p its-locale-filter-list="en" lang="en">To select metal type for characters needed to print a manuscript. (Metal type is stored in a type case, but because the number of Japanese characters is very large, an extra operation was invented that involves collecting type in a so-called 'bunsen box' before typesetting a manuscript using a composing stick.)</p>
               <p its-locale-filter-list="ja" lang="ja">原稿で指示された文字について，その活字を拾い集める作業．具体的には活字を配列してある活字ケースから文字を選び，文選箱に収める．</p>
             </td>
           </tr>
           <tr id="term.typeface">
-            <td class="xfq-term">typeface</td>
-            <td class="xfq-ja">書体</td>
-            <td class="xfq-transliteration">shotai<br/>しょたい</td>
-            <td class="xfq-def">
+            <td>typeface</td>
+            <td>書体</td>
+            <td>shotai<br/>しょたい</td>
+            <td>
               <p its-locale-filter-list="en" lang="en">A set of letters or symbols, which are designed to have coherent patterns to be used for printing or rendering to a computer screen. (JIS Z 8125)</p>
               <p its-locale-filter-list="ja" lang="ja">印字，画面表示などに使用するため，統一的な意図に基づいて作成された一組の文字又は記号の意匠．（JIS Z 8125）</p>
             </td>
           </tr>
           <tr id="term.unbreakable-characters-rule">
-            <td class="xfq-term">unbreakable characters rule</td>
-            <td class="xfq-ja">分割禁止</td>
-            <td class="xfq-transliteration">bunkatsu kinshi<br/>ぶんかつきんし</td>
-            <td class="xfq-def">
+            <td>unbreakable characters rule</td>
+            <td>分割禁止</td>
+            <td>bunkatsu kinshi<br/>ぶんかつきんし</td>
+            <td>
               <p its-locale-filter-list="en" lang="en">A line breaking rule that prohibits breaking a line between consecutive dashes or leaders, or between other specific combinations of characters.</p>
               <p its-locale-filter-list="ja" lang="ja">ダッシュ，リーダなど連続した同じ文字間，又は特定の文字の組の文字間では分割を禁止する規則．</p>
             </td>
           </tr>
           <tr id="term.underline">
-            <td class="xfq-term">underline</td>
-            <td class="xfq-ja">下線</td>
-            <td class="xfq-transliteration">kasen<br/>かせん</td>
-            <td class="xfq-def">
+            <td>underline</td>
+            <td>下線</td>
+            <td>kasen<br/>かせん</td>
+            <td>
               <p its-locale-filter-list="en" lang="en">A line drawn under a character or a run of text in horizontal writing mode. (JIS Z 8125)</p>
               <p its-locale-filter-list="ja" lang="ja">横組において，文字又は文字列の下に引いた線．（JIS Z 8125）</p>
             </td>
           </tr>
           <tr id="term.ura-kei">
-            <td class="xfq-term">ura-kei</td>
-            <td class="xfq-ja">裏罫</td>
-            <td class="xfq-transliteration">urakei<br/>うらけい</td>
-            <td class="xfq-def">
+            <td>ura-kei</td>
+            <td>裏罫</td>
+            <td>urakei<br/>うらけい</td>
+            <td>
               <p its-locale-filter-list="en" lang="en">Thick width line. Usually about 0.4mm. (JIS Z 8125)</p>
               <p its-locale-filter-list="ja" lang="ja">0.4mm程度の太さの実線．（JIS Z 8125）</p>
             </td>
           </tr>
           <tr id="term.vertical-writing-mode">
-            <td class="xfq-term">vertical writing mode</td>
-            <td class="xfq-ja">縦組</td>
-            <td class="xfq-transliteration">tate gumi<br/>たてぐみ</td>
-            <td class="xfq-def">
+            <td>vertical writing mode</td>
+            <td>縦組</td>
+            <td>tate gumi<br/>たてぐみ</td>
+            <td>
               <p its-locale-filter-list="en" lang="en">The process or the result of arranging characters on a line from top to bottom, of lines on a page from right to left, and/or of columns on a page from top to bottom. (JIS Z 8125)</p>
               <p its-locale-filter-list="ja" lang="ja">行においては文字を垂直方向に上から下へ，ページにおいて行を右から左へ，段を上から下へ配列すること．また，そのように文字が配置された状態．（JIS Z 8125）</p>
             </td>
           </tr>
           <tr id="term.warichu">
-            <td class="xfq-term">warichu (inline cutting note)</td>
-            <td class="xfq-ja">割注</td>
-            <td class="xfq-transliteration">warichū<br/>わりちゅう</td>
-            <td class="xfq-def">
+            <td>warichu (inline cutting note)</td>
+            <td>割注</td>
+            <td>warichū<br/>わりちゅう</td>
+            <td>
               <p its-locale-filter-list="en" lang="en">A note of two or more lines inserted in the text. It includes brackets which surround the note (JIS Z 8125)</p>
               <p its-locale-filter-list="ja" lang="ja">本文中で，複数行に割書きした注釈．割注には，割書きを囲む括弧類を含む．（JIS Z 8125）</p>
             </td>
           </tr>
           <tr id="term.weight">
-            <td class="xfq-term">weight</td>
-            <td class="xfq-ja">ウェイト</td>
-            <td class="xfq-transliteration">weito<br/>うぇいと</td>
-            <td class="xfq-def">
+            <td>weight</td>
+            <td>ウェイト</td>
+            <td>weito<br/>うぇいと</td>
+            <td>
               <p its-locale-filter-list="en" lang="en">A measurement of the thickness of fonts. (JIS Z 8125)</p>
               <p its-locale-filter-list="ja" lang="ja">書体における字形の画線の太さの指標．（JIS Z 8125）</p>
             </td>
           </tr>
           <tr id="term.widow">
-            <td class="xfq-term">widow</td>
-            <td class="xfq-ja">ウィドウ</td>
-            <td class="xfq-transliteration">widō<br/>うぃどう</td>
-            <td class="xfq-def">
+            <td>widow</td>
+            <td>ウィドウ</td>
+            <td>widō<br/>うぃどう</td>
+            <td>
               <p its-locale-filter-list="en" lang="en">The term in Western text layout to describe that the last line of a paragraph with only a few words  appears at the top of a new page or a column. (JIS Z 8125)</p>
               <p its-locale-filter-list="ja" lang="ja">欧文組版において，2単語程度である段落の最終行が，新しいページ又は段の第1行目にくること．（JIS Z 8125）</p>
             </td>
           </tr>
           <tr id="term.widow-adjustment">
-            <td class="xfq-term">widow adjustment</td>
-            <td class="xfq-ja">段落末尾処理</td>
-            <td class="xfq-transliteration">danraku matsubi shori<br/>だんらくまつびしょり</td>
-            <td class="xfq-def">
+            <td>widow adjustment</td>
+            <td>段落末尾処理</td>
+            <td>danraku matsubi shori<br/>だんらくまつびしょり</td>
+            <td>
               <p its-locale-filter-list="en" lang="en">A method of line composition to adjust lines  in a paragraph so that the last line consists of more than a given number of characters.</p>
               <p its-locale-filter-list="ja" lang="ja">段落の最終行に配置する行の字数が所定の字数未満にならないようにする処理．</p>
             </td>

--- a/index.html
+++ b/index.html
@@ -22737,2267 +22737,1745 @@
   <p its-locale-filter-list="ja" lang="ja">説明の最後に“（JIS Z 8125）”と示したものは，JIS Z 8125（印刷用語 ― デジタル印刷），“（JIS X 4051）”と示したものは，JIS X 4051（日本語文書の組版方法）の定義である．</p>
 
 
-<table class="termlist" its-locale-filter-list="en" lang="en">
-    <thead>
-      <tr>
-        <th>Terminology</th>
-        <th>Japanese</th>
-        <th>Romanized transliteration</th>
-        <th>Definition</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr id="term.back-matter">
-        <td>back matter</td>
-        <td>後付</td>
-        <td>atozuke</td>
-        <td>Appendices, supplements, glossary of terms, index and/or bibliography,  and so on, appended at the end of a book.</td>
-      </tr>
-      <tr id="term.base-characters">
-        <td>base character</td>
-        <td>親文字</td>
-        <td>oya moji</td>
-        <td>A character to be annotated by ruby, ornament characters, or emphasis dots.</td>
-      </tr>
-      <tr id="term.base-line">
-        <td>base line</td>
-        <td>並び線</td>
-        <td>narabi sen</td>
-        <td>A virtual line on which almost all glyphs in Western fonts are designed to be aligned. (JIS Z 8125)</td>
-      </tr>
-      <tr id="term.bibliography">
-        <td>bibliography</td>
-        <td>参考文献</td>
-        <td>sankō bunken</td>
-        <td>A list of works and papers related to the subjects in the text. (JIS Z 8125)</td>
-      </tr>
-      <tr id="term.blank-page">
-        <td>blank page</td>
-        <td>白ページ</td>
-        <td>shiro pēji</td>
-        <td>An empty page.</td>
-      </tr>
-      <tr id="term.bleed">
-        <td>bleed</td>
-        <td>裁切り</td>
-        <td>tachikiri</td>
-        <td>To print a picture or a tint to run off the edge of a trimmed page. (JIS Z 8125)</td>
-      </tr>
-      <tr id="term.block-direction">
-        <td>block direction</td>
-        <td>行送り方向</td>
-        <td>gyō okuri hōkō</td>
-        <td>The direction lines progress, one after the other. (JIS Z 8125)</td>
-      </tr>
-      <tr id="term.block-heading">
-        <td>block heading</td>
-        <td>別行見出し</td>
-        <td>betsugyōmidashi</td>
-        <td>A kind of heading styles. The heading is set as an independent line from basic text. (JIS Z 8125)</td>
-      </tr>
-      <tr id="term.bold">
-        <td>bold</td>
-        <td>太字</td>
-        <td>futoji</td>
-        <td>A kind of font style. Similer to bold in western typograpy.</td>
-      </tr>
-      <tr id="term.bound-on-the-left-hand-side">
-        <td>bound on the left-hand side</td>
-        <td>左綴じ</td>
-        <td>hidari toji</td>
-        <td>Binding of a book to be opened from the left.</td>
-      </tr>
-      <tr id="term.bound-on-the-right-hand-side">
-        <td>bound on the right-hand side</td>
-        <td>右綴じ</td>
-        <td>migi toji</td>
-        <td>Binding of a book to be opened from the right.</td>
-      </tr>
-      <tr id="term.bousen">
-        <td>bousen (sideline)</td>
-        <td>傍線</td>
-        <td>bōsen</td>
-        <td>A line drawn by the left or right side of a character or a run of text in vertical writing mode. (JIS Z 8125)</td>
-      </tr>
-      <tr id="term.break">
-        <td>break (a line)</td>
-        <td>（2行に）分割</td>
-        <td>bunkatsu</td>
-        <td>To place the first of two adjacent characters at the end of a line and the second at the head of a new line.</td>
-      </tr>
-      <tr id="term.caption">
-        <td>caption</td>
-        <td>キャプション</td>
-        <td>kyapushon</td>
-        <td>A title or a short description accompanying a picture, an illustration, or a table. (JIS Z 8125)</td>
-      </tr>
-      <tr id="term.cell">
-        <td>cell</td>
-        <td>こま</td>
-        <td>koma</td>
-        <td>Each element area of tables, cell.</td>
-      </tr>
-      <tr id="term.cell-contents">
-        <td>cell contents</td>
-        <td>こま内容</td>
-        <td>komanaiyō</td>
-        <td>The content of each cell in tables. (JIS X 4051)</td>
-      </tr>
-      <tr id="term.cell-padding">
-        <td>cell padding</td>
-        <td>こま余白</td>
-        <td>komayohaku</td>
-        <td>Spaces between line and cell in tables. (JIS X 4051)</td>
-      </tr>
-      <tr id="term.centering">
-        <td>centering</td>
-        <td>中央そろえ</td>
-        <td>chūō soroe</td>
-        <td>To align the center of a run of text that is shorter than a given line length to the center of a line. (JIS Z 8125)</td>
-      </tr>
-      <tr id="term.character-advance">
-        <td>character advance</td>
-        <td>字幅</td>
-        <td>jihaba</td>
-        <td>Size of a character frame in the inline direction, generally indicated as a ratio of the size of a full-width character, as in full-width, half-width, or quarter em width. Character advance is the width of a given character in horizontal writing-mode, while it is the height in vertical writing-mode.</td>
-      </tr>
-      <tr id="term.character-frame">
-        <td>character frame</td>
-        <td>（文字の）外枠</td>
-        <td>sotowaku</td>
-        <td>Rectangular area occupied by a character when it is set solid.</td>
-      </tr>
-      <tr id="term.character-shape">
-        <td>character shape</td>
-        <td>字形</td>
-        <td>jikei</td>
-        <td>Incarnation of a character by handwriting, printing or rendering to a computer screen. (JIS Z 8125)</td>
-      </tr>
-      <tr id="term.character-size">
-        <td>character size</td>
-        <td>文字サイズ</td>
-        <td>moji saizu</td>
-        <td>Dimensions of a character. Unless otherwise noted, it refers to the size of a character frame in the block direction.</td>
-      </tr>
-      <tr id="term.characters-not-ending-line">
-        <td>characters not ending line</td>
-        <td>行末禁則文字</td>
-        <td>gyōmatsu kinsoku moji</td>
-        <td>Any character for which "line-end prohibition rule" is invoked. (JIS Z 8125)</td>
-      </tr>
-      <tr id="term.characters-not-starting-line">
-        <td>characters not starting line</td>
-        <td>行頭禁則文字</td>
-        <td>gyōtō kinsoku moji</td>
-        <td>Any character for which "line-start prohibition rule" is invoked. (JIS Z 8125)</td>
-      </tr>
-      <tr id="term.chronological-history">
-        <td>chronological history</td>
-        <td>年譜</td>
-        <td>nenpu</td>
-        <td>Chronological tabels about the histories of persons or organizations.</td>
-      </tr>
-      <tr id="term.chronological-table">
-        <td>chronological table</td>
-        <td>年表</td>
-        <td>nenpyō</td>
-        <td>Chronologocal tables about histrical incidents. There are special types of chronological tables besides general ones, focused to specific view points and aspects.</td>
-      </tr>
-      <tr id="term.chu-boso-kei">
-        <td>chu-boso-kei</td>
-        <td>中細罫</td>
-        <td>chūbosokei</td>
-        <td>Middle width line, usually about 0.25mm.</td>
-      </tr>
-      <tr id="term.column">
-        <td>column</td>
-        <td>段</td>
-        <td>dan</td>
-        <td>A partition on a page in multi-column format. (JIS Z 8125)</td>
-      </tr>
-      <tr id="term.column-gap">
-        <td>column gap</td>
-        <td>段間</td>
-        <td>dankan</td>
-        <td>Amount of space between columns on a page. (JIS Z 8125)</td>
-      </tr>
-      <tr id="term.column-spanning">
-        <td>column spanning</td>
-        <td>段抜き</td>
-        <td>dannuki</td>
-        <td>A setting style of illustrations, tables, etc., over hanging to multiple columns. (JIS Z 8125)</td>
-      </tr>
-      <tr id="term.column-spanning-heading">
-        <td>column spanning heading</td>
-        <td>段抜きの見出し</td>
-        <td>dannuki no midashi</td>
-        <td>Headings using multiple columns.</td>
-      </tr>
-      <tr id="term.composition">
-        <td>composition</td>
-        <td>組版</td>
-        <td>kumihan</td>
-        <td>Process of arrangement of text, figures and/or pictures, etc on a page in a desired layout (design) in preparation for printing.</td>
-      </tr>
-      <tr id="term.compound-word">
-        <td>compound word (jukugo)</td>
-        <td>熟語</td>
-        <td>jukugo</td>
-        <td>A combination of two or more kanji characters which makes one word.</td>
-      </tr>
-      <tr id="term.continuous-pagination">
-        <td>continuous pagination</td>
-        <td>通しノンブル</td>
-        <td>tōshi nonburu</td>
-        <td><div>a) To number the pages of a book continuously across all those in the front matter, the text and the back matter.</div>
-          <div>b) To number the pages continuously across those of all books, such as a series published in separate volumes. Also to number the pages continuously across those of all issues of a periodical published in a year, aside from pagination per issue.</div>
-          <div>(JIS Z 8125)</div></td>
-      </tr>
-      <tr id="term.drop-heading">
-        <td>cut-in heading</td>
-        <td>窓見出し</td>
-        <td>madomidashi</td>
-        <td>A style of headings. Headings do not occupy the full lines, but share lines area with following main text lines.</td>
-      </tr>
-      <tr id="term.descender-line">
-        <td>descender line</td>
-        <td>ディセンダライン</td>
-        <td>disenda rain</td>
-        <td>A descender is the part of a letter extending below the base line, as in 'g', 'j', 'p', 'q', or 'y'.  A descender line is a virtual line drawn at the bottom of descender parallel to base line.</td>
-      </tr>
-      <tr id="term.double-running-head-method">
-        <td>double running head method</td>
-        <td>両柱方式</td>
-        <td>ryōbashira hōshiki</td>
-        <td>A method that prints running heads on both even and odd pages. (JIS Z 8125)</td>
-      </tr>
-      <tr id="term.emphasis-dots">
-        <td>emphasis dots</td>
-        <td>圏点</td>
-        <td>kenten</td>
-        <td>Symbols attached alongside a run of base characters to emphasize them. (JIS Z 8125)</td>
-      </tr>
-      <tr id="term.endnote">
-        <td>endnote</td>
-        <td>後注</td>
-        <td>kōchū</td>
-        <td>A set of notes placed at the end of a part, chapter, section, paragraph and so on, or at the end of a book. (JIS Z 8125)</td>
-      </tr>
-      <tr id="term.european-numerals">
-        <td>European numerals</td>
-        <td>アラビア数字</td>
-        <td>arabia sūji</td>
-        <td>Any of the symbols in [0-9] used to represent numbers. (JIS Z 8125)</td>
-      </tr>
-      <tr id="term.even-inter-character-spacing">
-        <td>even inter-character spacing</td>
-        <td>均等割り</td>
-        <td>kintō wari</td>
-        <td>A text setting with uniform inter-character spacing per line so that each line is aligned on the same line-head and line-end. (JIS Z 8125)</td>
-      </tr>
-      <tr id="term.even-tsumegumi">
-        <td>even tsumegumi</td>
-        <td>均等詰め</td>
-        <td>kintō zume</td>
-        <td>Adjustment of inter-character space by subtracting the same amount of space. (JIS Z 8125)</td>
-      </tr>
-      <tr id="term.face-tsumegumi">
-        <td>face tsumegumi</td>
-        <td>字面詰め</td>
-        <td>jizura zume</td>
-        <td>Adjustment of inter-character space by subtracting space to the extent that two letter faces are placed adjacent. (JIS Z 8125)</td>
-      </tr>
-      <tr id="term.fixed-inter-character-spacing">
-        <td>fixed inter-character spacing</td>
-        <td>アキ組</td>
-        <td>aki gumi</td>
-        <td>A text setting with a uniform inter-character spacing. (JIS Z 8125)</td>
-      </tr>
-      <tr id="term.fixed-width">
-        <td>fixed-width</td>
-        <td>モノスペース</td>
-        <td>monosupēsu</td>
-        <td>A characteristic of a font where the same character advance is assigned for all glyphs. (JIS Z 8125)</td>
-      </tr>
-      <tr id="term.font">
-        <td>font</td>
-        <td>フォント</td>
-        <td>fonto</td>
-        <td>A set of character glyphs of a given typeface. (JIS Z 8125)</td>
-      </tr>
-      <tr id="term.foot">
-        <td>foot</td>
-        <td>地</td>
-        <td>chi</td>
-        <td><div>a) The bottom part of a book or a page.</div>
-          <div>b) The bottom margin between the edge of a trimmed page and the hanmen (text area)</div>
-          <div>(JIS Z 8125)</div></td>
-      </tr>
-      <tr id="term.footnote">
-        <td>footnote</td>
-        <td>脚注</td>
-        <td>kyakuchū</td>
-        <td>A note in a smaller face than that of main text, placed at the bottom of a page. (JIS Z 8125)</td>
-      </tr>
-      <tr id="term.fore-edge">
-        <td>fore-edge</td>
-        <td>小口</td>
-        <td>koguchi</td>
-        <td><div>a) The three front trimmed edges of pages in a book.</div>
-          <div>b) The opposite sides of the gutter in a book.</div>
-          <div>(JIS Z 8125)</div></td>
-      </tr>
-      <tr id="term.front-matter">
-        <td>front matter</td>
-        <td>前付</td>
-        <td>maezuke</td>
-        <td>The first part of a book followed by the text, usually consisting of a forward, preface, table of contents, list of illustrations, acknowledgement and so on. </td>
-      </tr>
-      <tr id="term.full-width">
-        <td>full-width</td>
-        <td>全角</td>
-        <td>zenkaku</td>
-        <td><div>a) Relative index for the length which is equal to a given character size.</div>
-          <div> b) Character frame which character advance is equal to the amount referred to as a). A full-width character frame is  square in shape by definition.</div></td>
-      </tr>
-      <tr id="term.furigana">
-        <td>furigana</td>
-        <td>振り仮名</td>
-        <td>furigana</td>
-        <td>A method of ruby annotation using kana characters to indicate how to read kanji characters. This term derives from a Japanese verb "furu (to attach alongside)" and "kana", and has been used synonymously with "ruby". This document prefers to use the term "ruby".</td>
-      </tr>
-      <tr id="term.furikanji">
-        <td>furikanji</td>
-        <td>振り漢字</td>
-        <td>furikanji</td>
-        <td>A method of ruby annotation using Kanji characters for ruby instead of kana characters.</td>
-      </tr>
-      <tr id="term.furiwake">
-        <td>furiwake</td>
-        <td>振分け</td>
-        <td>furiwake</td>
-        <td>A method of placing multiple runs of text in a line. (JIS Z 8125)</td>
-      </tr>
-      <tr id="term.general-ruby">
-        <td>general-ruby</td>
-        <td>総ルビ</td>
-        <td>sō rubi</td>
-        <td>A method of ruby annotation that attaches ruby text for all Kanji characters in the text. (JIS Z 8125)</td>
-      </tr>
-      <tr id="term.group-ruby">
-        <td>group-ruby</td>
-        <td>グループルビ</td>
-        <td>gurūpu rubi</td>
-        <td>A method of ruby character distribution such that the length of ruby text matches to that of the base text by giving the same adjusted amount of space between ruby characters.</td>
-      </tr>
-      <tr id="term.gutter">
-        <td>gutter</td>
-        <td>のど</td>
-        <td>nodo</td>
-        <td><div>a) The binding side of a spread of a book.</div>
-          <div>b) the margin between the binding edge of a book and the hanmen (text area).</div>
-          <div>c) The part of a book where all pages are bound together to the book spine.</div>
-          <div>(JIS Z 8125)</div></td>
-      </tr>
-      <tr id="term.gyodori">
-        <td>gyodori</td>
-        <td>行取り</td>
-        <td>gyōdori</td>
-        <td>To keep block direction area for headings and so on, along with line units in kihon-hanmen. The width of the gyodori space is calculated with following fomula: line width × number of lines + line gap × (number of lines − 1). However, deceptively, in middle of page or column, the line gaps before and after seem to be added to the gyodori space, and in the start of page or column, the line gap after seems to be added to the gyodori space.</td>
-      </tr>
-      <tr id="term.half-em">
-        <td>half em</td>
-        <td>二分</td>
-        <td>nibu</td>
-        <td>Half of the full-width size. (JIS Z 8125)</td>
-      </tr>
-      <tr id="term.half-em-space">
-        <td>half em space</td>
-        <td>二分アキ</td>
-        <td>nibu aki</td>
-        <td>Amount of space that is half size of em space.</td>
-      </tr>
-      <tr id="term.half-width">
-        <td>half-width</td>
-        <td>半角</td>
-        <td>hankaku</td>
-        <td>Character frame which has a character advance of a half em.</td>
-      </tr>
-      <tr id="term.han-tobira">
-        <td>han-tobira</td>
-        <td>半扉</td>
-        <td>hantobira</td>
-        <td>A simplified version of naka-tobira, the verso side of which text of the new part starts. (JIS Z 8125)</td>
-      </tr>
-      <tr id="term.hanmen">
-        <td>hanmen (page content area)</td>
-        <td>版面</td>
-        <td>hanmen</td>
-        <td>Actual printed area in a page excluding the margins. (note: Running heads and page numbers are not part of hanmen.) (JIS Z 8125)</td>
-      </tr>
-      <tr id="term.head">
-        <td>head</td>
-        <td>天</td>
-        <td>ten</td>
-        <td><div>a) The top part of a book or a page.</div>
-          <div>b) The top margin between the top edge of a trimmed page and the hanmen (text area)</div>
-          <div>(JIS Z 8125)</div></td>
-      </tr>
-      <tr id="term.heading">
-        <td>heading</td>
-        <td>見出し</td>
-        <td>midashi</td>
-        <td><div>a) A title of a paper or an article.</div>
-          <div>b) A title for each section of a book, paper or article.</div>
-          <div>(JIS Z 8125)</div></td>
-      </tr>
-      <tr id="term.headnote">
-        <td>headnote</td>
-        <td>頭注</td>
-        <td>tōchū</td>
-        <td>A kind of notes in vertical writing style, head area in kihon-hanmen is kept beforehand, and notes are set with smaller size font than main text.</td>
-      </tr>
-      <tr id="term.horizontal-writing-mode">
-        <td>horizontal writing mode</td>
-        <td>横組</td>
-        <td>yokogumi</td>
-        <td>The process or the result of arranging characters on a line from left to right, of lines on a page from top to bottom, and/or of columns on a page from left to right. (JIS Z 8125)</td>
-      </tr>
-      <tr id="term.hyphenation">
-        <td>hyphenation</td>
-        <td>ハイフネーション</td>
-        <td>haifunēshon</td>
-        <td>A method of breaking a line by dividing a Western word at the end of a line and adding a hyphen  at the end of the first half of the syllable. </td>
-      </tr>
-      <tr id="term.ideographic-numerals">
-        <td>ideographic numerals</td>
-        <td>漢数字</td>
-        <td>kansūji</td>
-        <td>Ideographic characters representing numbers.</td>
-      </tr>
-      <tr id="term.illustrations">
-        <td>illustrations</td>
-        <td>図版</td>
-        <td>zuhan</td>
-        <td>A general term referring to a diagram, chart, cut, figure, picture and the like, to be used for printed materials.</td>
-      </tr>
-      <tr id="term.independent-pagination">
-        <td>independent pagination</td>
-        <td>別ノンブル</td>
-        <td>betsu nonburu</td>
-        <td>To number the pages of the front matter, the text and the back matter independently. (JIS Z 8125)</td>
-      </tr>
-      <tr id="term.index">
-        <td>index</td>
-        <td>索引</td>
-        <td>sakuin</td>
-        <td>A list of terms or subjects with page numbers for where they are referred to in a single or multiple volumes of a book. (JIS Z 8125)</td>
-      </tr>
-      <tr id="term.inline-direction">
-        <td>inline direction</td>
-        <td>字詰め方向</td>
-        <td>jizume hōkō</td>
-        <td>Text direction in a line. (JIS Z 8125)</td>
-      </tr>
-      <tr id="term.inseparable-characters-rule">
-        <td>inseparable characters rule</td>
-        <td>分離禁止</td>
-        <td>bunri kinshi</td>
-        <td>A line adjustment rule that prohibits inserting any space between specific combinations of characters. (JIS Z 8125)</td>
-      </tr>
-      <tr id="term.inter-character-space">
-        <td>inter-character space</td>
-        <td>字間</td>
-        <td>jikan</td>
-        <td>Amount of space between two adjacent character frames on the same line.</td>
-      </tr>
-      <tr id="term.itemization">
-        <td>itemization</td>
-        <td>箇条書き</td>
-        <td>kajō gaki</td>
-        <td>To list ordered or unordered items one under the other. (JIS Z 8125)</td>
-      </tr>
-      <tr id="term.japanese-and-western-mixed-text-composition">
-        <td>Japanese and Western mixed text composition</td>
-        <td>和欧文混植</td>
-        <td>waō konshoku</td>
-        <td>To mix Japanese text and Western text in the same composition.</td>
-      </tr>
-      <tr id="term.japanese-characters">
-        <td>Japanese characters</td>
-        <td>和文文字</td>
-        <td>wabun moji</td>
-        <td>Characters used to compose Japanese text.</td>
-      </tr>
-      <tr id="term.japanese-gothic-face">
-        <td>Japanese gothic face</td>
-        <td>ゴシック体</td>
-        <td>goshikku tai</td>
-        <td>A Japanese typeface, with strokes almost the same in thickness, and no special ornament on a stroke such as a triangular element commonly seen in the Mincho typeface. Used for text emphasis and/or headings.</td>
-      </tr>
-      <tr id="term.jidori">
-        <td>jidori</td>
-        <td>字取り</td>
-        <td>jidori</td>
-        <td>A method of aligning a run of text to both edges which is specified by a position to start and the length calculated by a specified number of a given size of characters. (JIS Z 8125)</td>
-      </tr>
-      <tr id="term.jouyou-kanji-table">
-        <td>Jouyou Kanji Table</td>
-        <td>常用漢字表</td>
-        <td>jōyō kanji hyō</td>
-        <td>The official list of Kanji characters "for general use in society. such as in legal and official documents, newspapers, magazines, broadcasting and the like". It was established in 1981 as a reference guide for people in composing contemporary Japanese. It listed 1,945 of Kanji characters together with their orthographic shapes, Japanese native reading (Kun), Chinese derived reading (On) and other useful information.</td>
-      </tr>
-      <tr id="term.jukugo-ruby">
-        <td>jukugo-ruby</td>
-        <td>熟語ルビ</td>
-        <td>jukugo rubi</td>
-        <td>A method of ruby character distribution determined by two functions, one is to provide reading for each Kanji character, the other is to give a united appearance attached to a word.</td>
-      </tr>
-      <tr id="term.kabe">
-        <td>kabe</td>
-        <td>かべ</td>
-        <td>kabe</td>
-        <td>Main text is bounced before the dannuki headings, illustrations, tables, etc., like balls and walls.</td>
-      </tr>
-      <tr id="term.kanbun-composition">
-        <td>kanbun composition</td>
-        <td>漢文</td>
-        <td>kanbun</td>
-        <td>Chinese classic text (or  text in the same style) with various auxiliary symbols so that it can be read as Japanese text.</td>
-      </tr>
-      <tr id="term.katatsuki">
-        <td>katatsuki (katatsuki-ruby)</td>
-        <td>肩付き（肩付きルビ）</td>
-        <td>katatsuki (katatsuki rubi)</td>
-        <td>A method of attaching ruby at the upper right of each base character. (JIS Z 8125)</td>
-      </tr>
-      <tr id="term.kihon-hanmen">
-        <td>kihon-hanmen</td>
-        <td>基本版面</td>
-        <td>kihon hanmen</td>
-        <td>The default dimensions of the main area of a typeset page specified by text direction, number of columns, character size, number of characters in a line, number of lines in a column, inter-line spacing and inter-column spacing. (JIS X 4051)</td>
-      </tr>
-      <tr id="term.label-name">
-        <td>label name</td>
-        <td>ラベル名</td>
-        <td>raberumei</td>
-        <td>Text following or followed by numbers for illustrations, tables, headings and running headings. (JIS X 4051)</td>
-      </tr>
-      <tr id="term.letter-face">
-        <td>letter face</td>
-        <td>字面</td>
-        <td>jizura</td>
-        <td>Area in which glyph is drawn. (JIS Z 8125)</td>
-      </tr>
-      <tr id="term.letterpress-printing">
-        <td>letterpress printing</td>
-        <td>活字組版</td>
-        <td>katsuji kumihan</td>
-        <td>The traditional printing method using movable type.</td>
-      </tr>
-      <tr id="term.line-adjustment">
-        <td>line adjustment</td>
-        <td>行の調整処理</td>
-        <td>gyō no chōsei shori</td>
-        <td>A method of aligning both edges of all lines to be the same given length by removing or adding adjustable spaces.</td>
-      </tr>
-      <tr id="term.line-adjustment-by-hanging-punctuation">
-        <td>line adjustment by hanging punctuation</td>
-        <td>ぶら下げ組</td>
-        <td>burasage gumi</td>
-        <td>A line breaking rule to avoid commas or full stops at a line head (which is prohibited in Japanese typography) by taking them back to the end of the previous line beyond the specified line length. (JIS Z 8125)</td>
-      </tr>
-      <tr id="term.line-adjustment-by-inter-character-space-expansion">
-        <td>line adjustment by inter-character space expansion</td>
-        <td>追出し処理</td>
-        <td>oidashi shori</td>
-        <td>A line breaking rule that aligns both edges of a line by expanding inter-character spaces. (JIS Z 8125).</td>
-      </tr>
-      <tr id="term.line-adjustment-by-inter-character-space-reduction">
-        <td>line adjustment by inter-character space reduction</td>
-        <td>追込み処理</td>
-        <td>oikomi shori</td>
-        <td>A line breaking rule that aligns both edges of a line by removing adjustable spaces such as conditional spaces for punctuation marks. (JIS Z 8125).</td>
-      </tr>
-      <tr id="term.line-breaking-rules">
-        <td>line breaking rules</td>
-        <td>禁則処理</td>
-        <td>kinsoku shori</td>
-        <td>A set of rules to avoid prohibited layout in Japanese typography, such as "line-start prohibition rule", "line-end prohibition rule", inseparable or unbreakable character sequences and so on. (JIS Z 8125)</td>
-      </tr>
-      <tr id="term.line-end">
-        <td>line end</td>
-        <td>行末</td>
-        <td>gyōmatsu</td>
-        <td>The position at which a line ends. (JIS Z 8125)</td>
-      </tr>
-      <tr id="term.line-end-alignment">
-        <td>line end alignment</td>
-        <td>行末そろえ</td>
-        <td>gyōmatsu soroe</td>
-        <td>To align a run of text to the line end. (JIS Z 8125)</td>
-      </tr>
-      <tr id="term.line-end-indent">
-        <td>line end indent</td>
-        <td>字上げ</td>
-        <td>jiage</td>
-        <td>To reserve a certain amount of space before the default position of a line end. (JIS Z 8125)</td>
-      </tr>
-      <tr id="term.line-feed">
-        <td>line feed</td>
-        <td>行送り</td>
-        <td>gyō okuri</td>
-        <td>The distance between two adjacent lines measured by their reference points. (JIS Z 8125)</td>
-      </tr>
-      <tr id="term.line-gap">
-        <td>line gap</td>
-        <td>行間</td>
-        <td>gyōkan</td>
-        <td>The smallest amount of space between adjacent lines.</td>
-      </tr>
-      <tr id="term.line-head">
-        <td>line head</td>
-        <td>行頭</td>
-        <td>gyōtō</td>
-        <td>The  position at which a line starts. (JIS Z 8125)</td>
-      </tr>
-      <tr id="term.line-head-alignment">
-        <td>line head alignment</td>
-        <td>行頭そろえ</td>
-        <td>gyōtō soroe</td>
-        <td>To align a run of text to the line head. (JIS Z 8125)</td>
-      </tr>
-      <tr id="term.line-head-indent">
-        <td>line head indent</td>
-        <td>字下げ</td>
-        <td>jisage</td>
-        <td>To reserve a certain amount of space after the default position of a line head. (JIS Z 8125)</td>
-      </tr>
-      <tr id="term.line-length">
-        <td>line length</td>
-        <td>行長</td>
-        <td>gyōchō</td>
-        <td>Length of a line with a pre-defined number of characters. When the line is indented at the line head or the line end, it is length of the line from the specified amount of line head indent to the specified amount of line end indent.</td>
-      </tr>
-      <tr id="term.line-end-prohibition-rule">
-        <td>line-end prohibition rule</td>
-        <td>行末禁則</td>
-        <td>gyōmatsu kinsoku</td>
-        <td>A line breaking rule that prohibits specific characters at a line end. (JIS Z 8125)</td>
-      </tr>
-      <tr id="term.line-start-prohibition-rule">
-        <td>line-start prohibition rule</td>
-        <td>行頭禁則</td>
-        <td>gyōtō kinsoku</td>
-        <td>A line breaking rule that prohibits specific characters at a line head. (JIS Z 8125)</td>
-      </tr>
-      <tr id="term.main-text">
-        <td>main text</td>
-        <td>本文</td>
-        <td>honbun</td>
-        <td><div>a) The principal part of  a book, usually preceded by the front matter, followed by the back matter.</div>
-          <div>b) The principal part of an article excluding figures, tables, heading, notes, leads and so on.</div>
-          <div>c) The content of a page excluding running heads and page numbers.</div>
-          <div>d) The net contents of a book excluding covers, end papers, insets and so on.</div>
-          <div>(JIS Z 8125)</div></td>
-      </tr>
-      <tr id="term.matrix">
-        <td>matrix</td>
-        <td>母型</td>
-        <td>bokei</td>
-        <td>A metal mold from which movable type is cast.</td>
-      </tr>
-      <tr id="term.mawarikomi">
-        <td>mawarikomi</td>
-        <td>回り込み</td>
-        <td>mawarikomi</td>
-        <td>Text setting style to fill the left line direction space, which is happen to appear because of the arragnement of illustrations, tables, etc. (JIS Z 8125)</td>
-      </tr>
-      <tr id="term.mincho-typeface">
-        <td>Mincho typeface</td>
-        <td>明朝体</td>
-        <td>minchōtai</td>
-        <td>A major style of Japanese font. Horizontal lines are thin and vertical lines are thick. At the start position and the end position, there are triangular figure representing press of brush. Kana are designed to balance the Kanji design. In Japanese text setting, Mincho typeface is most frequently used for main text, especially for long text.
-          Similar to "serif" of Western typography.</td>
-      </tr>
-      <tr id="term.mixed-text-composition">
-        <td>mixed text composition</td>
-        <td>混植</td>
-        <td>konshoku</td>
-        <td><div>a) To interleave Japanese text with Western text in a line (Japanese and Western mixed text composition).</div>
-          <div> b) To compose text with different sizes of characters (mixed size composition).</div>
-          <div> c) To compose text with different typefaces (mixed typeface composition).</div>
-          <div>(JIS Z 8125)</div></td>
-      </tr>
-      <tr id="term.mono-ruby">
-        <td>mono-ruby</td>
-        <td>モノルビ</td>
-        <td>mono rubi</td>
-        <td>A method of ruby distribution where a run of ruby text is attached to each base character. (JIS Z 8125)</td>
-      </tr>
-      <tr id="term.multi-column-format">
-        <td>multi-column format</td>
-        <td>段組</td>
-        <td>dangumi</td>
-        <td>A format of text on a page where  text is divided into two or more sections (columns) in the inline direction and each column is separated by a certain amount of space (column space). (JIS Z 8125)</td>
-      </tr>
-      <tr id="term.multivolume-work">
-        <td>multivolume work</td>
-        <td>多巻物</td>
-        <td>takanmono</td>
-        <td>A set of work published in two or more volumes, as in the complete work or the first/last half volumes.</td>
-      </tr>
-      <tr id="term.naka-tobira">
-        <td>naka-tobira</td>
-        <td>中扉</td>
-        <td>naka tobira</td>
-        <td>A recto or a page inserted to divide two different parts in a book. It often has a title or other text to describe the new part. (JIS Z 8125)</td>
-      </tr>
-      <tr id="term.nakatsuki">
-        <td>nakatsuki (nakatsuki-ruby)</td>
-        <td>中付き（中付きルビ）</td>
-        <td>nakatsuki (nakatsuki rubi)</td>
-        <td>A method of ruby character distribution where each ruby character is aligned to the vertical center of the corresponding base character in vertical writing mode, or to the horizontal center of the base character in horizontal writing mode. (JIS Z 8125)</td>
-      </tr>
-      <tr id="term.new-column">
-        <td>new column</td>
-        <td>改段</td>
-        <td>kaidan</td>
-        <td>In multi-column setting, to change to new column before the end of current column.</td>
-      </tr>
-      <tr id="term.new-recto">
-        <td>new recto</td>
-        <td>改丁</td>
-        <td>kaichō</td>
-        <td>To start a new heading or something on a odd page. (JIS Z 8125)</td>
-      </tr>
-      <tr id="term.note">
-        <td>note</td>
-        <td>注</td>
-        <td>chū</td>
-        <td>Explanatory information added to terms, figures or tables. (JIS Z 8125)</td>
-      </tr>
-      <tr id="term.number-of-characters-per-line">
-        <td>number of characters per line</td>
-        <td>字詰め</td>
-        <td>jizume</td>
-        <td>Number of characters in a line to specify the length of lines. (JIS Z 8125)</td>
-      </tr>
-      <tr id="term.number-of-columns">
-        <td>number of columns</td>
-        <td>段数</td>
-        <td>dansū</td>
-        <td>Number of columns on a page. (JIS Z 8125)</td>
-      </tr>
-      <tr id="term.omote-kei">
-        <td>omote-kei</td>
-        <td>表罫</td>
-        <td>omotekei</td>
-        <td>Thin width line. Usually about 0.12mm. (JIS Z 8125)</td>
-      </tr>
-      <tr id="term.one-em-space">
-        <td>one em space</td>
-        <td>全角アキ</td>
-        <td>zenkaku aki</td>
-        <td>Amount of space that is full-width size.</td>
-      </tr>
-      <tr id="term.one-third-em">
-        <td>one third em</td>
-        <td>三分</td>
-        <td>sanbu</td>
-        <td>One third of the full-width size. (JIS Z 8125)</td>
-      </tr>
-      <tr id="term.one-third-em-space">
-        <td>one third em space</td>
-        <td>三分アキ</td>
-        <td>sanbu aki</td>
-        <td>Amount of space that is one third size of em space.</td>
-      </tr>
-      <tr id="term.one-third-ruby">
-        <td>one-third-ruby</td>
-        <td>三分ルビ</td>
-        <td>sanbu rubi</td>
-        <td>Ruby characters, narrow enough so that three can fit within the width of a full-width base character.</td>
-      </tr>
-      <tr id="term.original-pattern">
-        <td>original pattern</td>
-        <td>原図</td>
-        <td>genzu</td>
-        <td>An original drawn pattern of a character image to be used for a printing type or a digitized glyph.</td>
-      </tr>
-      <tr id="term.ornament-characters">
-        <td>ornament characters</td>
-        <td>添え字</td>
-        <td>soeji</td>
-        <td>A superscript or subscript attached to a base character. (JIS Z 8125)</td>
-      </tr>
-      <tr id="term.page">
-        <td>page</td>
-        <td>ページ</td>
-        <td>pēji</td>
-        <td>A side of a sheet of paper in a written work such as a book. (JIS Z 8125)</td>
-      </tr>
-      <tr id="term.page-break">
-        <td>page break</td>
-        <td>改ページ</td>
-        <td>kai pēji</td>
-        <td>To end a page even if it is not full and to start a new page with the next paragraph, a new heading and so on. (JIS Z 8125)</td>
-      </tr>
-      <tr id="term.page-format">
-        <td>page format</td>
-        <td>組体裁</td>
-        <td>kumi teisai</td>
-        <td>The layout and presentation of a page with text, graphics and other elements for a publication such as a book.</td>
-      </tr>
-      <tr id="term.page-number">
-        <td>page number</td>
-        <td>ノンブル</td>
-        <td>nonburu</td>
-        <td>A sequential number to indicate the order of pages in a publication. (JIS Z 8125)</td>
-      </tr>
-      <tr id="term.para-ruby">
-        <td>para-ruby</td>
-        <td>パラルビ</td>
-        <td>para rubi</td>
-        <td>A method of ruby annotation where ruby text is only attached to selected Kanji characters in the text. (JIS Z 8125)</td>
-      </tr>
-      <tr id="term.paragraph">
-        <td>paragraph</td>
-        <td>段落</td>
-        <td>danraku</td>
-        <td>A group of sentences to be processed for line composition. A paragraph consists of one or more lines. (JIS Z 8125)</td>
-      </tr>
-      <tr id="term.paragraph-break">
-        <td>paragraph break</td>
-        <td>改行</td>
-        <td>kaigyō</td>
-        <td>To start a new line to indicate a new paragraph.</td>
-      </tr>
-      <tr id="term.paragraph-format">
-        <td>paragraph format</td>
-        <td>段落整形</td>
-        <td>danraku seikei</td>
-        <td>A format of a paragraph, as in line head indent or line end indent.</td>
-      </tr>
-      <tr id="term.parallel-note">
-        <td>parallel-note</td>
-        <td>並列注</td>
-        <td>heiretsuchū</td>
-        <td>Areas of notes are kept when the kihon-hanmen is designed. Related notes are set in these areas, with page unit or spread unit. Parallel-note is the general name for head note (in vertical writing mode), foot note (in vertical writing mode) and side note (in horizontal writing mode).</td>
-      </tr>
-      <tr id="term.point">
-        <td>point</td>
-        <td>ポイント</td>
-        <td>pointo</td>
-        <td>A measurement unit of character size. 1 point is equal to 0.3514mm (see JIS Z 8305). There is another unit to measure character sizes called Q, where 1Q is equivalent to 0.25mm.</td>
-      </tr>
-      <tr id="term.printing-types">
-        <td>printing types</td>
-        <td>活字</td>
-        <td>katsuji</td>
-        <td>Movable type used for letterpress printing.</td>
-      </tr>
-      <tr id="term.proportional">
-        <td>proportional</td>
-        <td>プロポーショナル</td>
-        <td>puropōshonaru</td>
-        <td>A characteristic of a font where  character advance is different per glyph. (JIS Z 8125)</td>
-      </tr>
-      <tr id="term.punctuation-marks">
-        <td>punctuation marks</td>
-        <td>約物</td>
-        <td>yakumono</td>
-        <td>A general term referring to the symbols used in text composition to help make the meaning of text clearer, as in commas, full stops, question marks, brackets, diereses and so on. (JIS Z 8125)</td>
-      </tr>
-      <tr id="term.quarter-em">
-        <td>quarter em</td>
-        <td>四分</td>
-        <td>shibu</td>
-        <td>Quarter size of full-width.</td>
-      </tr>
-      <tr id="term.quarter-em-space">
-        <td>quarter em space</td>
-        <td>四分アキ</td>
-        <td>shibu aki</td>
-        <td>Amount of space that is a quarter of an em space in size.</td>
-      </tr>
-      <tr id="term.quarter-em-width">
-        <td>quarter em width</td>
-        <td>四分角</td>
-        <td>shibu kaku</td>
-        <td>Character frame which has a character advance  of a quarter em. (JIS X 4051)</td>
-      </tr>
-      <tr id="term.quotation">
-        <td>quotation</td>
-        <td>引用文</td>
-        <td>in-yōbun</td>
-        <td>Excerps from other published works. (JIS Z 8125)</td>
-      </tr>
-      <tr id="term.reference-marks">
-        <td>reference marks</td>
-        <td>合印</td>
-        <td>aijirushi</td>
-        <td>A symbol or short run of text attached to a specific part of text, to which notes are provided followed by the corresponding marks.</td>
-      </tr>
-      <tr id="term.reverse-pagination">
-        <td>reverse pagination</td>
-        <td>逆ノンブル</td>
-        <td>gyaku nonburu</td>
-        <td>Numbering pages of a book backwards. (JIS Z 8125)</td>
-      </tr>
-      <tr id="term.roman-numerals">
-        <td>Roman numerals</td>
-        <td>ローマ数字</td>
-        <td>rōma sūji</td>
-        <td>Numerals represented by upper case or lower case of Latin letters. (JIS Z 8125)</td>
-      </tr>
-      <tr id="term.ruby">
-        <td>ruby</td>
-        <td>ルビ</td>
-        <td>rubi</td>
-        <td>Supplementary small characters indicating pronunciation, meaning, etc. for the character or the block of characters they annotate. (JIS Z 8125) (Sometimes these annotations are referred to as "furigana".)</td>
-      </tr>
-      <tr id="term.run-in-heading">
-        <td>run-in heading</td>
-        <td>同行見出し</td>
-        <td>dōgyōmidashi</td>
-        <td>A kind of heading style to continue main text just after the heading without line break.</td>
-      </tr>
-      <tr id="term.running-head">
-        <td>running head</td>
-        <td>柱</td>
-        <td>hashira</td>
-        <td>A page element which contains information on the title of the book, chapter, section and so on, printed outside the area of the hanmen. (JIS Z 8125)</td>
-      </tr>
-      <tr id="term.second-level-heading">
-        <td>second level heading</td>
-        <td>中見出し</td>
-        <td>nakamidashi</td>
-        <td>Second level and middle size heading between first level heading and third level heading. (JIS Z 8125)</td>
-      </tr>
-      <tr id="term.sidenote">
-        <td>sidenote</td>
-        <td>傍注</td>
-        <td>bōchū</td>
-        <td>A kind of notes, in vertical writing mode with spread unit, and related notes are set from the left end of left page with smaller size font than the main text. A kind of notes, in horizontal writing mode, the realm is kept beforhand in right side or fore-edge side of kihon-hanmen, and related notes are set in the realm with smaller size font than main text.</td>
-      </tr>
-      <tr id="term.single-line-alignment-method">
-        <td>single line alignment method</td>
-        <td>そろえ</td>
-        <td>soroe</td>
-        <td>To align a run of text that is shorter than a given line length to designated positions.</td>
-      </tr>
-      <tr id="term.single-running-head-method">
-        <td>single running head method</td>
-        <td>片柱方式</td>
-        <td>katabashira hōshiki</td>
-        <td>A method that puts running heads only on odd pages. (JIS Z 8125)</td>
-      </tr>
-      <tr id="term.small-kana">
-        <td>small kana</td>
-        <td>小書きの仮名</td>
-        <td>kogaki no kana</td>
-        <td>Kana with smaller letter faces to be used mainly for representing contracted sounds or prolonged vowels. (JIS Z 8125)</td>
-      </tr>
-      <tr id="term.solid-setting">
-        <td>solid setting</td>
-        <td>ベタ組</td>
-        <td>beta gumi</td>
-        <td>To arrange characters with no inter-character space between adjacent character frames.</td>
-      </tr>
-      <tr id="term.space">
-        <td>space</td>
-        <td>アキ</td>
-        <td>aki</td>
-        <td>Amount of space between adjacent characters or lines. It also refers to the blank area between the edges of a hanmen or an illustration and text or other hanmen elements.</td>
-      </tr>
-      <tr id="term.spread">
-        <td>spread</td>
-        <td>見開き</td>
-        <td>mihiraki</td>
-        <td>Any two facing pages when opening a book and the like. (JIS Z 8125)</td>
-      </tr>
-      <tr id="term.subscript">
-        <td>subscript (inferior)</td>
-        <td>下付き</td>
-        <td>shitatsuki</td>
-        <td>Smaller face of characters, attached to the lower right or the lower left of a normal size character. (JIS Z 8125)</td>
-      </tr>
-      <tr id="term.subtitle">
-        <td>subtitle</td>
-        <td>副題</td>
-        <td>fukudai</td>
-        <td>Secondary title for headings, subtile. (JIS X 4051)</td>
-      </tr>
-      <tr id="term.superscript">
-        <td>superscript (superior)</td>
-        <td>上付き</td>
-        <td>uwatsuki</td>
-        <td>Smaller face of characters, attached to the upper right or the upper left of a normal size character. (JIS Z 8125)</td>
-      </tr>
-      <tr id="term.tab-setting">
-        <td>tab setting</td>
-        <td>タブ処理</td>
-        <td>tabu shori</td>
-        <td>A method of line composition to align one or more runs of text to  designated positions on a line.</td>
-      </tr>
-      <tr id="term.table">
-        <td>table</td>
-        <td>表</td>
-        <td>hyō</td>
-        <td>Formatted data consisting of characters or numbers, arranged in cells and sometimes divided by lines, in order to present the data in a way that is easier to understand. (JIS Z 8125)</td>
-      </tr>
-      <tr id="term.table-of-contents">
-        <td>table of contents</td>
-        <td>目次</td>
-        <td>mokuji</td>
-        <td>A list of headings of contents of a book in page order or arranged by subjects, with page numbers on which each section begins. (JIS Z 8125)</td>
-      </tr>
-      <tr id="term.tate-chu-yoko">
-        <td>tate-chu-yoko</td>
-        <td>縦中横</td>
-        <td>tate chū yoko</td>
-        <td>To typeset a (small) group of characters horizontally within a vertical line of main text.</td>
-      </tr>
-      <tr id="term.tentsuki">
-        <td>tentsuki</td>
-        <td>天付き</td>
-        <td>tentsuki</td>
-        <td><div>a) To remove conditional space from opening brackets at a line head to align the line head to the ones of the adjacent lines.</div>
-          <div> b) Not to add the default line head indent for the first line of a paragraph so as to align all line heads.</div>
-          <div>(JIS Z 8125)</div></td>
-      </tr>
-      <tr id="term.text-direction">
-        <td>text direction</td>
-        <td>組方向</td>
-        <td>kumi hōkō</td>
-        <td>Horizontal setting or vertical setting. (JIS Z 8125)</td>
-      </tr>
-      <tr id="term.third-level-heading">
-        <td>third level heading</td>
-        <td>小見出し</td>
-        <td>komidashi</td>
-        <td>Headings for smallest or minimum unit of main text in books.</td>
-      </tr>
-      <tr id="term.top-level-heading">
-        <td>top level heading</td>
-        <td>大見出し</td>
-        <td>ōmidashi</td>
-        <td>Headings for largest or muximum unit of main text in books.</td>
-      </tr>
-      <tr id="term.touyou-kanji-table">
-        <td>Touyou Kanji Table</td>
-        <td>当用漢字表</td>
-        <td>tōyō kanji hyō</td>
-        <td>The official list of Kanji characters established in 1946, which was designed to restrict the Kanji characters for general use in society to only those 1850 specified in the list. The list together with other related tables was superseded by the Jouyou Kanji Table.</td>
-      </tr>
-      <tr id="term.trim-size">
-        <td>trim size</td>
-        <td>仕上りサイズ</td>
-        <td>shiagari saizu</td>
-        <td>Dimensions of a full page in a publication, including margins. (JIS Z 8125)</td>
-      </tr>
-      <tr id="term.tsumegumi">
-        <td>tsumegumi</td>
-        <td>詰め組</td>
-        <td>tsumegumi</td>
-        <td>Adjustment of inter-character space by making the distance between the letter face of adjacent characters shorter than that produced by solid setting. (JIS Z 8125) </td>
-      </tr>
-      <tr id="term.type-picking">
-        <td>type-picking</td>
-        <td>文選</td>
-        <td>bunsen</td>
-        <td>To select metal type for characters needed to print a manuscript. (Metal type is stored in a type case, but because the number of Japanese characters is very large, an extra operation was invented that involves collecting type in a so-called 'bunsen box' before typesetting a manuscript using a composing stick.)</td>
-      </tr>
-      <tr id="term.typeface">
-        <td>typeface</td>
-        <td>書体</td>
-        <td>shotai</td>
-        <td>A set of letters or symbols, which are designed to have coherent patterns to be used for printing or rendering to a computer screen. (JIS Z 8125)</td>
-      </tr>
-      <tr id="term.unbreakable-characters-rule">
-        <td>unbreakable characters rule</td>
-        <td>分割禁止</td>
-        <td>bunkatsu kinshi</td>
-        <td>A line breaking rule that prohibits breaking a line between consecutive dashes or leaders, or between other specific combinations of characters.</td>
-      </tr>
-      <tr id="term.underline">
-        <td>underline</td>
-        <td>下線</td>
-        <td>kasen</td>
-        <td>A line drawn under a character or a run of text in horizontal writing mode. (JIS Z 8125)</td>
-      </tr>
-      <tr id="term.ura-kei">
-        <td>ura-kei</td>
-        <td>裏罫</td>
-        <td>urakei</td>
-        <td>Thick width line. Usually about 0.4mm. (JIS Z 8125)</td>
-      </tr>
-      <tr id="term.vertical-writing-mode">
-        <td>vertical writing mode</td>
-        <td>縦組</td>
-        <td>tate gumi</td>
-        <td>The process or the result of arranging characters on a line from top to bottom, of lines on a page from right to left, and/or of columns on a page from top to bottom. (JIS Z 8125)</td>
-      </tr>
-      <tr id="term.warichu">
-        <td>warichu (inline cutting note)</td>
-        <td>割注</td>
-        <td>warichū</td>
-        <td>A note of two or more lines inserted in the text. It includes brackets which surround the note (JIS Z 8125)</td>
-      </tr>
-      <tr id="term.weight">
-        <td>weight</td>
-        <td>ウェイト</td>
-        <td>weito</td>
-        <td>A measurement of the thickness of fonts. (JIS Z 8125)</td>
-      </tr>
-      <tr id="term.widow">
-        <td>widow</td>
-        <td>ウィドウ</td>
-        <td>widō</td>
-        <td>The term in Western text layout to describe that the last line of a paragraph with only a few words  appears at the top of a new page or a column. (JIS Z 8125)</td>
-      </tr>
-      <tr id="term.widow-adjustment">
-        <td>widow adjustment</td>
-        <td>段落末尾処理</td>
-        <td>danraku matsubi shori</td>
-        <td>A method of line composition to adjust lines  in a paragraph so that the last line consists of more than a given number of characters.</td>
-      </tr>
-    </tbody>
-  </table>
-
-
-
-
-
-<table class="termlist" its-locale-filter-list="ja" lang="ja">
-    <thead>
-      <tr>
-        <th>用語</th>
-        <th>よみ</th>
-        <th>英語</th>
-        <th>定義</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr id="ja-term.reference-marks">
-        <td>合印</td>
-        <td>あいじるし</td>
-        <td>reference marks</td>
-        <td>注と本文文字列などの該当項目とを対応させるために該当項目に付ける文字列．</td>
-      </tr>
-      <tr id="ja-term.space">
-        <td>アキ</td>
-        <td>あき</td>
-        <td>space</td>
-        <td>隣接する文字又は隣接する行の間隔．また，版面，図版などの端から文字列などの端までの間隔．</td>
-      </tr>
-      <tr id="ja-term.fixed-inter-character-spacing">
-        <td>アキ組</td>
-        <td>あきぐみ</td>
-        <td>fixed inter-character spacing</td>
-        <td>字間に一定のアキを入れて文字を配置する方法．（JIS Z 8125）</td>
-      </tr>
-      <tr id="ja-term.back-matter">
-        <td>後付</td>
-        <td>あとづけ</td>
-        <td>back matter</td>
-        <td>書籍の巻末に付けられる付録，補遺，語彙解説，索引，文献など．</td>
-      </tr>
-      <tr id="ja-term.european-numerals">
-        <td>アラビア数字</td>
-        <td>あらびあすうじ</td>
-        <td>European numerals</td>
-        <td>インドに始まり，アラビアからヨーロッパに伝わった数字．（算用数字，洋数字ともいう．）（JIS Z 8125）</td>
-      </tr>
-      <tr id="ja-term.quotation">
-        <td>引用文</td>
-        <td>いんようぶん</td>
-        <td>quotation</td>
-        <td>公表された他の著作物から，その一部を引用して利用するもの．（JIS Z 8125）</td>
-      </tr>
-      <tr id="ja-term.widow">
-        <td>ウィドウ</td>
-        <td>うぃどう</td>
-        <td>widow</td>
-        <td>欧文組版において，2単語程度である段落の最終行が，新しいページ又は段の第1行目にくること．（JIS Z 8125）</td>
-      </tr>
-      <tr id="ja-term.weight">
-        <td>ウェイト</td>
-        <td>うぇいと</td>
-        <td>weight</td>
-        <td>書体における字形の画線の太さの指標．（JIS Z 8125）</td>
-      </tr>
-      <tr id="ja-term.ura-kei">
-        <td>裏罫</td>
-        <td>うらけい</td>
-        <td>ura-kei</td>
-        <td>0.4mm程度の太さの実線．（JIS Z 8125）</td>
-      </tr>
-      <tr id="ja-term.superscript">
-        <td>上付き</td>
-        <td>うわつき</td>
-        <td>superscript (superior)</td>
-        <td>小さい字面の文字で，通常の大きさの文字の右肩又は左肩に付けて配置する文字．（JIS Z 8125）</td>
-      </tr>
-      <tr id="ja-term.line-adjustment-by-inter-character-space-reduction">
-        <td>追込み処理</td>
-        <td>おいこみしょり</td>
-        <td>line adjustment by inter-character space reduction</td>
-        <td>禁則処理の1つの方法であって，約物の前後などを詰めて行頭行末そろえをすること（JIS Z 8125）．行頭行末そろえとは，各行の最初の文字を行頭にそろえ，かつ各行の最後の文字を行末にそろえて配置する方法（JIS Z 8125）．</td>
-      </tr>
-      <tr id="ja-term.line-adjustment-by-inter-character-space-expansion">
-        <td>追出し処理</td>
-        <td>おいだししょり</td>
-        <td>line adjustment by inter-character space expansion</td>
-        <td>禁則処理の1つの方法であって，字間を広げて行頭行末そろえをすること（JIS Z 8125）．行頭行末そろえとは，各行の最初の文字を行頭にそろえ，かつ各行の最後の文字を行末にそろえて配置する方法（JIS Z 8125）．</td>
-      </tr>
-      <tr id="ja-term.top-level-heading">
-        <td>大見出し</td>
-        <td>おおみだし</td>
-        <td>top level heading</td>
-        <td>書籍などで，区分の最大のまとまりに付ける標題．</td>
-      </tr>
-      <tr id="ja-term.omote-kei">
-        <td>表罫</td>
-        <td>おもてけい</td>
-        <td>omote-kei</td>
-        <td>0.1mm程度の太さの実線．（JIS Z 8125）</td>
-      </tr>
-      <tr id="ja-term.base-characters">
-        <td>親文字</td>
-        <td>おやもじ</td>
-        <td>base character</td>
-        <td>ルビ，添え字又は圏点が付けられたとき，その対象となる文字．</td>
-      </tr>
-      <tr id="ja-term.paragraph-break">
-        <td>改行</td>
-        <td>かいぎょう</td>
-        <td>paragraph break</td>
-        <td>段落の区切りなどを示すために行を改めること．</td>
-      </tr>
-      <tr id="ja-term.new-column">
-        <td>改段</td>
-        <td>かいだん</td>
-        <td>new column</td>
-        <td>段組で段の途中にもかかわらず，次の見出しなどを新しい段の始めから配置すること．</td>
-      </tr>
-      <tr id="ja-term.new-recto">
-        <td>改丁</td>
-        <td>かいちょう</td>
-        <td>new recto</td>
-        <td>奇数ページより新規に見出しなどを始めること．（JIS Z 8125）</td>
-      </tr>
-      <tr id="ja-term.page-break">
-        <td>改ページ</td>
-        <td>かいぺーじ</td>
-        <td>page break</td>
-        <td>奇数ページ・偶数ページに関わらず，ページの途中であっても次の文章・見出しなどを次のページから新しく始めること．（JIS Z 8125）</td>
-      </tr>
-      <tr id="ja-term.itemization">
-        <td>箇条書き</td>
-        <td>かじょうがき</td>
-        <td>itemization</td>
-        <td>順序付き，又は順序を明示することなく項目を列挙すること．（JIS Z 8125）</td>
-      </tr>
-      <tr id="ja-term.underline">
-        <td>下線</td>
-        <td>かせん</td>
-        <td>underline</td>
-        <td>横組において，文字又は文字列の下に引いた線．（JIS Z 8125）</td>
-      </tr>
-      <tr id="ja-term.katatsuki">
-        <td>肩付き（肩付きルビ）</td>
-        <td>かたつき</td>
-        <td>katatsuki (katatsuki-ruby)</td>
-        <td>縦組において，ルビを親文字の右肩に付けて配置する方法．（JIS Z 8125）</td>
-      </tr>
-      <tr id="ja-term.single-running-head-method">
-        <td>片柱方式</td>
-        <td>かたばしらほうしき</td>
-        <td>single running head method</td>
-        <td>柱を奇数ページだけに掲げること．（JIS Z 8125）</td>
-      </tr>
-      <tr id="ja-term.printing-types">
-        <td>活字</td>
-        <td>かつじ</td>
-        <td>printing types</td>
-        <td>文字組版に使用するもので，文字・数字・記号類などの字面を逆向きで凸状に，鉛合金などで鋳造した角柱．</td>
-      </tr>
-      <tr id="ja-term.letterpress-printing">
-        <td>活字組版</td>
-        <td>かつじくみはん</td>
-        <td>letterpress printing</td>
-        <td>可動式の活字，その他の材料を用いた伝統的な組版．</td>
-      </tr>
-      <tr id="ja-term.kabe">
-        <td>かべ</td>
-        <td>かべ</td>
-        <td>kabe</td>
-        <td>段組において，版面の中に配置した段抜きの見出し・図版・表組などを壁にたとえ，その手前で文章の行の流れを折り返すこと．</td>
-      </tr>
-      <tr id="ja-term.ideographic-numerals">
-        <td>漢数字</td>
-        <td>かんすうじ</td>
-        <td>ideographic numerals</td>
-        <td>漢字の一二三…十などを用いて表す数字．</td>
-      </tr>
-      <tr id="ja-term.kanbun-composition">
-        <td>漢文</td>
-        <td>かんぶん</td>
-        <td>kanbun composition</td>
-        <td>中国の古典文（又はそれにならった文体の文）について，日本語の文として読むことが可能になるように，読むための様々な補助記号を付けた文．</td>
-      </tr>
-      <tr id="ja-term.kihon-hanmen">
-        <td>基本版面</td>
-        <td>きほんはんめん</td>
-        <td>kihon-hanmen</td>
-        <td>本の基本として設計される版面体裁．組方向，段数，文字サイズ，字詰め数，行数，行間及び段間で指定する．（JIS X 4051）</td>
-      </tr>
-      <tr id="ja-term.footnote">
-        <td>脚注</td>
-        <td>きゃくちゅう</td>
-        <td>footnote</td>
-        <td>ページの下部に，本文よりも小さな文字で組まれた注釈．（JIS Z 8125）</td>
-      </tr>
-      <tr id="ja-term.reverse-pagination">
-        <td>逆ノンブル</td>
-        <td>ぎゃくのんぶる</td>
-        <td>reverse pagination</td>
-        <td>巻末の方からページの番号を開始するノンブル．（JIS Z 8125）</td>
-      </tr>
-      <tr id="ja-term.caption">
-        <td>キャプション</td>
-        <td>きゃぷしょん</td>
-        <td>caption</td>
-        <td>写真，図版，表などにそえる標題や簡潔な説明文．（JIS Z 8125）</td>
-      </tr>
-      <tr id="ja-term.line-feed">
-        <td>行送り</td>
-        <td>ぎょうおくり</td>
-        <td>line feed</td>
-        <td>隣接する行同士の基準点から基準点までの距離．（JIS Z 8125）</td>
-      </tr>
-      <tr id="ja-term.block-direction">
-        <td>行送り方向</td>
-        <td>ぎょうおくりほうこう</td>
-        <td>block direction</td>
-        <td>1つの行が次の行へと続く方向．（JIS Z 8125）</td>
-      </tr>
-      <tr id="ja-term.line-gap">
-        <td>行間</td>
-        <td>ぎょうかん</td>
-        <td>line gap</td>
-        <td>隣接する行の文字の外枠間の距離．</td>
-      </tr>
-      <tr id="ja-term.line-length">
-        <td>行長</td>
-        <td>ぎょうちょう</td>
-        <td>line length</td>
-        <td>基本版面で設定した行の行頭から行末までの長さ．字下げ又は字上げした場合は，指定された行頭から行末までの長さ．</td>
-      </tr>
-      <tr id="ja-term.line-head">
-        <td>行頭</td>
-        <td>ぎょうとう</td>
-        <td>line head</td>
-        <td>1つの行の始まる位置．（JIS Z 8125）</td>
-      </tr>
-      <tr id="ja-term.line-start-prohibition-rule">
-        <td>行頭禁則</td>
-        <td>ぎょうとうきんそく</td>
-        <td>line-start prohibition rule</td>
-        <td>行頭に特定の文字を置くことを禁止する規則．（JIS Z 8125）</td>
-      </tr>
-      <tr id="ja-term.characters-not-starting-line">
-        <td>行頭禁則文字</td>
-        <td>ぎょうとうきんそくもじ</td>
-        <td>characters not starting line</td>
-        <td>行頭禁則の条件に該当する文字．（JIS Z 8125）</td>
-      </tr>
-      <tr id="ja-term.line-head-alignment">
-        <td>行頭そろえ</td>
-        <td>ぎょうとうそろえ</td>
-        <td>line head alignment</td>
-        <td>文字列の最初の文字を行頭の位置に合わせること．（JIS Z 8125）</td>
-      </tr>
-      <tr id="ja-term.gyodori">
-        <td>行取り</td>
-        <td>ぎょうどり</td>
-        <td>gyodori</td>
-        <td>見出しなどを配置する領域の行送り方向の大きさを行単位で確保すること．この場合，行送り方向の見出しの占めるスペースは，“行の幅×行数＋行間×（行数－1）”となる．しかし，見た目には，ページ（又は段）の途中に見出しを配置する場合は，そのスペースの前及び後ろの行間が加わり，ページ（又は段）の先頭に見出しを配置する場合は，そのスペースの後ろの行間が加わった大きさとなる．</td>
-      </tr>
-      <tr id="ja-term.line-adjustment">
-        <td>行の調整処理</td>
-        <td>ぎょうのちょうせいしょり</td>
-        <td>line adjustment</td>
-        <td>指定された行長にするために，字間を詰める又は空ける処理．</td>
-      </tr>
-      <tr id="ja-term.line-end">
-        <td>行末</td>
-        <td>ぎょうまつ</td>
-        <td>line end</td>
-        <td>1つの行の終わる位置．（JIS Z 8125）</td>
-      </tr>
-      <tr id="ja-term.line-end-prohibition-rule">
-        <td>行末禁則</td>
-        <td>ぎょうまつきんそく</td>
-        <td>line-end prohibition rule</td>
-        <td>行末に特定の文字を置くことを禁止する規則．（JIS Z 8125）</td>
-      </tr>
-      <tr id="ja-term.characters-not-ending-line">
-        <td>行末禁則文字</td>
-        <td>ぎょうまつきんそくもじ</td>
-        <td>characters not ending line</td>
-        <td>行末禁則の条件に該当する文字．（JIS Z 8125）</td>
-      </tr>
-      <tr id="ja-term.line-end-alignment">
-        <td>行末そろえ</td>
-        <td>ぎょうまつそろえ</td>
-        <td>line end alignment</td>
-        <td>文字列の最後の文字を行末の位置に合わせること．（JIS Z 8125）</td>
-      </tr>
-      <tr id="ja-term.line-breaking-rules">
-        <td>禁則処理</td>
-        <td>きんそくしょり</td>
-        <td>line breaking rules</td>
-        <td>行頭禁則，行末禁則，分離（分割）禁止などの禁則を避けるために行われる処理．（JIS Z 8125）</td>
-      </tr>
-      <tr id="ja-term.even-tsumegumi">
-        <td>均等詰め</td>
-        <td>きんとうづめ</td>
-        <td>even tsumegumi</td>
-        <td>ベタ組より字間を一定量詰めて文字を配置する方法．（JIS Z 8125）</td>
-      </tr>
-      <tr id="ja-term.even-inter-character-spacing">
-        <td>均等割り</td>
-        <td>きんとうわり</td>
-        <td>even inter-character spacing</td>
-        <td>字間を均等に空け，文字列の両端を行頭及び行末にそろえること．（JIS Z 8125）</td>
-      </tr>
-      <tr id="ja-term.page-format">
-        <td>組体裁</td>
-        <td>くみていさい</td>
-        <td>page format</td>
-        <td>本などの仕上りサイズ及びそこに配置する文字その他の表示体裁．</td>
-      </tr>
-      <tr id="ja-term.composition">
-        <td>組版</td>
-        <td>くみはん</td>
-        <td>composition</td>
-        <td>原稿及びレイアウト（デザイン）の指定に従って，文字・図版・写真などを配置する作業の総称．</td>
-      </tr>
-      <tr id="ja-term.text-direction">
-        <td>組方向</td>
-        <td>くみほうこう</td>
-        <td>text direction</td>
-        <td>横組又は縦組．（JIS Z 8125）</td>
-      </tr>
-      <tr id="ja-term.group-ruby">
-        <td>グループルビ</td>
-        <td>ぐるーぷるび</td>
-        <td>group-ruby</td>
-        <td>複数の親文字で構成される語全体に掛かるように均等間隔にルビを付けて配置する方法．</td>
-      </tr>
-      <tr id="ja-term.original-pattern">
-        <td>原図</td>
-        <td>げんず</td>
-        <td>original pattern</td>
-        <td>印刷用の文字の元となる描かれた文字．</td>
-      </tr>
-      <tr id="ja-term.emphasis-dots">
-        <td>圏点</td>
-        <td>けんてん</td>
-        <td>emphasis dots</td>
-        <td>文字のそばに付けて注意を促したり，その部分を強調したりするしるし．（JIS Z 8125）</td>
-      </tr>
-      <tr id="ja-term.endnote">
-        <td>後注</td>
-        <td>こうちゅう</td>
-        <td>endnote</td>
-        <td>本文の編・章・節・段落などの区分の終わり又は巻末にまとめて入れる注釈．（JIS Z 8125）</td>
-      </tr>
-      <tr id="ja-term.small-kana">
-        <td>小書きの仮名</td>
-        <td>こがきのかな</td>
-        <td>small kana</td>
-        <td>拗音，促音，外来語などを書き表す場合に用いる，字面を小さくした仮名．捨て仮名，半音ともいう．（JIS Z 8125）</td>
-      </tr>
-      <tr id="ja-term.fore-edge">
-        <td>小口</td>
-        <td>こぐち</td>
-        <td>fore-edge</td>
-        <td><div>a）<span class="term_listbody">本のページの綴じていない三方の切り口．</span></div>
-          <div>b）<span class="term_listbody">のどの反対側．</span></div>
-          <div>（JIS Z 8125）</div></td>
-      </tr>
-      <tr id="ja-term.japanese-gothic-face">
-        <td>ゴシック体</td>
-        <td>ごしっくたい</td>
-        <td>Japanese gothic face</td>
-        <td>文字の線がほぼ同じ幅を持った和文書体で，明朝体のように三角形のうろこが付いていない．強調する部分や見出しなどに用いる．</td>
-      </tr>
-      <tr id="ja-term.cell">
-        <td>こま</td>
-        <td>こま</td>
-        <td>cell</td>
-        <td>表においては，罫などで小さな領域に区切るが，この隣り合う縦及び横の罫などで区切られた個々の領域．</td>
-      </tr>
-      <tr id="ja-term.cell-contents">
-        <td>こま内容</td>
-        <td>こまないよう</td>
-        <td>cell contents</td>
-        <td>表のこまの中に表示されるもの．（JIS X 4051）</td>
-      </tr>
-      <tr id="ja-term.cell-padding">
-        <td>こま余白</td>
-        <td>こまよはく</td>
-        <td>cell padding</td>
-        <td>表の罫線とこまとの間の空白領域．（JIS X 4051）</td>
-      </tr>
-      <tr id="ja-term.third-level-heading">
-        <td>小見出し</td>
-        <td>こみだし</td>
-        <td>third level heading</td>
-        <td>書籍などで，区分の最小のまとまりに付ける標題．</td>
-      </tr>
-      <tr id="ja-term.mixed-text-composition">
-        <td>混植</td>
-        <td>こんしょく</td>
-        <td>mixed text composition</td>
-        <td><div>a）<span class="term_listbody">和文と欧文とを併用して組版すること（和欧文混植）．</span></div>
-          <div>b）<span class="term_listbody">異なる大きさの文字を併用して組版すること（異サイズ混植）．</span></div>
-          <div>c）<span class="term_listbody">異なる書体を使用して組版すること（異書体混植）．</span></div>
-          <div>（JIS Z 8125）</div></td>
-      </tr>
-      <tr id="ja-term.index">
-        <td>索引</td>
-        <td>さくいん</td>
-        <td>index</td>
-        <td>1冊又は複数冊からなる本の中の語句，事項などを抜き出して配列し，それぞれの該当ページ番号を示したもの．（JIS Z 8125）</td>
-      </tr>
-      <tr id="ja-term.bibliography">
-        <td>参考文献</td>
-        <td>さんこうぶんけん</td>
-        <td>bibliography</td>
-        <td>本文の内容に関係の深い他の著書，論文を記したもの．（JIS Z 8125）</td>
-      </tr>
-      <tr id="ja-term.one-third-em">
-        <td>三分</td>
-        <td>さんぶ</td>
-        <td>one third em</td>
-        <td>全角の3分の1の長さ．（JIS Z 8125）</td>
-      </tr>
-      <tr id="ja-term.one-third-em-space">
-        <td>三分アキ</td>
-        <td>さんぶあき</td>
-        <td>one third em space</td>
-        <td>三分の空き量．</td>
-      </tr>
-      <tr id="ja-term.one-third-ruby">
-        <td>三分ルビ</td>
-        <td>さんぶるび</td>
-        <td>one-third-ruby</td>
-        <td>全角の字幅の親文字1字に対し，3文字のルビを親文字からはみ出させないように付けるためのルビ．</td>
-      </tr>
-      <tr id="ja-term.trim-size">
-        <td>仕上りサイズ</td>
-        <td>しあがりさいず</td>
-        <td>trim size</td>
-        <td>仕上げ裁ちした印刷物の寸法．（JIS Z 8125）</td>
-      </tr>
-      <tr id="ja-term.line-end-indent">
-        <td>字上げ</td>
-        <td>じあげ</td>
-        <td>line end indent</td>
-        <td>行末の位置を行頭方向に移すこと．（JIS Z 8125）</td>
-      </tr>
-      <tr id="ja-term.inter-character-space">
-        <td>字間</td>
-        <td>じかん</td>
-        <td>inter-character space</td>
-        <td>同一行の隣接する2つの文字の外枠の間隔．</td>
-      </tr>
-      <tr id="ja-term.character-shape">
-        <td>字形</td>
-        <td>じけい</td>
-        <td>character shape</td>
-        <td>文字について，手書き，印字，画面表示などによって実際に図形として表現したもの．（JIS Z 8125）</td>
-      </tr>
-      <tr id="ja-term.line-head-indent">
-        <td>字下げ</td>
-        <td>じさげ</td>
-        <td>line head indent</td>
-        <td>行頭の位置を行末方向に移すこと．（JIS Z 8125）</td>
-      </tr>
-      <tr id="ja-term.subscript">
-        <td>下付き</td>
-        <td>したつき</td>
-        <td>subscript (inferior)</td>
-        <td>小さい字面の文字で，通常の大きさの文字の右下又は左下に付けて配置する文字．（JIS Z 8125）</td>
-      </tr>
-      <tr id="ja-term.number-of-characters-per-line">
-        <td>字詰め</td>
-        <td>じづめ</td>
-        <td>number of characters per line</td>
-        <td>行長を文字サイズの倍数で指定する場合の文字数．（JIS Z 8125）</td>
-      </tr>
-      <tr id="ja-term.inline-direction">
-        <td>字詰め方向</td>
-        <td>じづめほうこう</td>
-        <td>inline direction</td>
-        <td>1行の中で，1つの文字から次の文字へと続く方向．（JIS Z 8125）</td>
-      </tr>
-      <tr id="ja-term.letter-face">
-        <td>字面</td>
-        <td>じづら</td>
-        <td>letter face</td>
-        <td>字形の，実際に表示される領域．（JIS Z 8125）</td>
-      </tr>
-      <tr id="ja-term.face-tsumegumi">
-        <td>字面詰め</td>
-        <td>じづらづめ</td>
-        <td>face tsumegumi</td>
-        <td>仮名や約物等の字面が重ならない程度まで詰めて文字を配置する方法．（JIS Z 8125）</td>
-      </tr>
-      <tr id="ja-term.jidori">
-        <td>字取り</td>
-        <td>じどり</td>
-        <td>jidori</td>
-        <td>使用文字サイズの倍数で指定した長さの両端に文字列の先頭と最後尾をそろえて文字を配置する方法．（JIS Z 8125）</td>
-      </tr>
-      <tr id="ja-term.character-advance">
-        <td>字幅</td>
-        <td>じはば</td>
-        <td>character advance</td>
-        <td>文字を配列する方向（字詰め方向）の文字の外枠の大きさ．一般に字幅の絶対値を文字サイズで除した値で示す．全角，半角，四分角など．字幅は，横組では文字の幅となるが，縦組では文字の高さとなる．</td>
-      </tr>
-      <tr id="ja-term.quarter-em">
-        <td>四分</td>
-        <td>しぶ</td>
-        <td>quarter em</td>
-        <td>全角の4分の1の長さ．（JIS Z 8125）</td>
-      </tr>
-      <tr id="ja-term.quarter-em-space">
-        <td>四分アキ</td>
-        <td>しぶあき</td>
-        <td>quarter em space</td>
-        <td>四分の空き量．</td>
-      </tr>
-      <tr id="ja-term.quarter-em-width">
-        <td>四分角</td>
-        <td>しぶかく</td>
-        <td>quarter em width</td>
-        <td>字幅が，全角の1/4である文字の外枠．（JIS X 4051）</td>
-      </tr>
-      <tr id="ja-term.compound-word">
-        <td>熟語</td>
-        <td>じゅくご</td>
-        <td>compound word (jukugo)</td>
-        <td>2字以上の漢字が結合し，一語となったもの．</td>
-      </tr>
-      <tr id="ja-term.jukugo-ruby">
-        <td>熟語ルビ</td>
-        <td>じゅくごるび</td>
-        <td>jukugo-ruby</td>
-        <td>熟語の個々の漢字の読みと熟語としてのまとまりの2つを考慮して配置位置を決めるルビの配置方法．</td>
-      </tr>
-      <tr id="ja-term.jouyou-kanji-table">
-        <td>常用漢字表</td>
-        <td>じょうようかんじひょう</td>
-        <td>Jouyou Kanji Table</td>
-        <td>1981年に制定された一般の社会生活において，現代の国語を書き表す場合の漢字使用の目安を示す表．1945字の漢字，その音訓，字体などが示されている．</td>
-      </tr>
-      <tr id="ja-term.typeface">
-        <td>書体</td>
-        <td>しょたい</td>
-        <td>typeface</td>
-        <td>印字，画面表示などに使用するため，統一的な意図に基づいて作成された一組の文字又は記号の意匠．（JIS Z 8125）</td>
-      </tr>
-      <tr id="ja-term.blank-page">
-        <td>白ページ</td>
-        <td>しろぺーじ</td>
-        <td>blank page</td>
-        <td>何も表示しないページ．</td>
-      </tr>
-      <tr id="ja-term.illustrations">
-        <td>図版</td>
-        <td>ずはん</td>
-        <td>illustrations</td>
-        <td>印刷物の中に掲げる図，グラフ，カット，イラストレーション，写真などの総称．</td>
-      </tr>
-      <tr id="ja-term.full-width">
-        <td>全角</td>
-        <td>ぜんかく</td>
-        <td>full-width</td>
-        <td><div>a）<span class="term_listbody">文字サイズに等しい長さの相対単位．</span></div>
-          <div>b）<span class="term_listbody">字幅がaである文字の外枠．この場合，文字の外枠は正方形になる．</span></div></td>
-      </tr>
-      <tr id="ja-term.one-em-space">
-        <td>全角アキ</td>
-        <td>ぜんかくあき</td>
-        <td>one em space</td>
-        <td>全角の空き量．</td>
-      </tr>
-      <tr id="ja-term.general-ruby">
-        <td>総ルビ</td>
-        <td>そうるび</td>
-        <td>general-ruby</td>
-        <td>文中のすべての漢字にルビを付けること．（JIS Z 8125）</td>
-      </tr>
-      <tr id="ja-term.ornament-characters">
-        <td>添え字</td>
-        <td>そえじ</td>
-        <td>ornament characters</td>
-        <td>文字のそばに付ける上付き文字又は下付き文字．（JIS Z 8125）</td>
-      </tr>
-      <tr id="ja-term.character-frame">
-        <td>（文字の）外枠</td>
-        <td>そとわく</td>
-        <td>character frame</td>
-        <td>1つの文字が組版の際に占有する仮想的な長方形の領域．</td>
-      </tr>
-      <tr id="ja-term.single-line-alignment-method">
-        <td>そろえ</td>
-        <td>そろえ</td>
-        <td>single line alignment method</td>
-        <td>1行の文字列について，指定した位置に文字の配置位置を合わせること．</td>
-      </tr>
-      <tr id="ja-term.multivolume-work">
-        <td>多巻物</td>
-        <td>たかんもの</td>
-        <td>multivolume work</td>
-        <td>全集，上下巻など，1部の本で2冊以上の図書で構成されているもの．</td>
-      </tr>
-      <tr id="ja-term.bleed">
-        <td>裁切り</td>
-        <td>たちきり</td>
-        <td>bleed</td>
-        <td>写真，平網などを断裁位置いっぱいまで印刷すること．（JIS Z 8125）</td>
-      </tr>
-      <tr id="ja-term.vertical-writing-mode">
-        <td>縦組</td>
-        <td>たてぐみ</td>
-        <td>vertical writing mode</td>
-        <td>行においては文字を垂直方向に上から下へ，ページにおいて行を右から左へ，段を上から下へ配列すること．また，そのように文字が配置された状態．（JIS Z 8125）</td>
-      </tr>
-      <tr id="ja-term.tate-chu-yoko">
-        <td>縦中横</td>
-        <td>たてちゅうよこ</td>
-        <td>tate-chu-yoko</td>
-        <td>縦組の行中で，文字を縦向きのまま横組にすること．</td>
-      </tr>
-      <tr id="ja-term.tab-setting">
-        <td>タブ処理</td>
-        <td>たぶしょり</td>
-        <td>tab setting</td>
-        <td>行において，1つ又は複数の文字列を指定位置に合わせて配置する処理．</td>
-      </tr>
-      <tr id="ja-term.column">
-        <td>段</td>
-        <td>だん</td>
-        <td>column</td>
-        <td>段組において，分割された1区分．（JIS Z 8125）</td>
-      </tr>
-      <tr id="ja-term.column-gap">
-        <td>段間</td>
-        <td>だんかん</td>
-        <td>column gap</td>
-        <td>段組の段と段との間の空き．（JIS Z 8125）</td>
-      </tr>
-      <tr id="ja-term.multi-column-format">
-        <td>段組</td>
-        <td>だんぐみ</td>
-        <td>multi-column format</td>
-        <td>連続する1系列の文章を1ページの中で，字詰め方向において，2つ以上の部分（段）に分割し，各部分の間には空白（段間）を設けて文字を配置する方法．（JIS Z 8125）</td>
-      </tr>
-      <tr id="ja-term.number-of-columns">
-        <td>段数</td>
-        <td>だんすう</td>
-        <td>number of columns</td>
-        <td>1ページ内に配置される段の数．（JIS Z 8125）</td>
-      </tr>
-      <tr id="ja-term.column-spanning">
-        <td>段抜き</td>
-        <td>だんぬき</td>
-        <td>column spanning</td>
-        <td>段組のページにおいて，見出し，図版などを複数段にまたがって配置すること．（JIS Z 8125）</td>
-      </tr>
-      <tr id="ja-term.column-spanning-heading">
-        <td>段抜きの見出し</td>
-        <td>だんぬきのみだし</td>
-        <td>column spanning heading</td>
-        <td>段抜きにして配置する見出し．</td>
-      </tr>
-      <tr id="ja-term.paragraph">
-        <td>段落</td>
-        <td>だんらく</td>
-        <td>paragraph</td>
-        <td>行組版処理の処理単位となる1つ以上の文の集まり．段落は，1行又は連続した複数の行からなる．（JIS Z 8125）</td>
-      </tr>
-      <tr id="ja-term.paragraph-format">
-        <td>段落整形</td>
-        <td>だんらくせいけい</td>
-        <td>paragraph format</td>
-        <td>字下げ，字上げ，インデントなどの段落の書式．</td>
-      </tr>
-      <tr id="ja-term.widow-adjustment">
-        <td>段落末尾処理</td>
-        <td>だんらくまつびしょり</td>
-        <td>widow adjustment</td>
-        <td>段落の最終行に配置する行の字数が所定の字数未満にならないようにする処理．</td>
-      </tr>
-      <tr id="ja-term.foot">
-        <td>地</td>
-        <td>ち</td>
-        <td>foot</td>
-        <td><div>a）<span class="term_listbody">本又はページの下部．</span></div>
-          <div>b）<span class="term_listbody">ページの下部の仕上り線と版面までの余白部分．</span></div>
-          <div>（JIS Z 8125）</div></td>
-      </tr>
-      <tr id="ja-term.note">
-        <td>注</td>
-        <td>ちゅう</td>
-        <td>note</td>
-        <td>語句，図版，表などに加える補助的な説明・解釈．（JIS Z 8125）</td>
-      </tr>
-      <tr id="ja-term.centering">
-        <td>中央そろえ</td>
-        <td>ちゅうおうそろえ</td>
-        <td>centering</td>
-        <td>文字列の中央を，行頭と行末との中央の位置に合わせること．（JIS Z 8125）</td>
-      </tr>
-      <tr id="ja-term.chu-boso-kei">
-        <td>中細罫</td>
-        <td>ちゅうぼそけい</td>
-        <td>chu-boso-kei</td>
-        <td>0.25mm程度の太さの実線．</td>
-      </tr>
-      <tr id="ja-term.tsumegumi">
-        <td>詰め組</td>
-        <td>つめぐみ</td>
-        <td>tsumegumi</td>
-        <td>ベタ組より字送りを詰めて文字を配置する方法（JIS Z 8125）．なお，字送りとは，同一行の隣接する文字同士の基準点から基準点までの距離（JIS Z 8125）．</td>
-      </tr>
-      <tr id="ja-term.descender-line">
-        <td>ディセンダライン</td>
-        <td>でぃせんだらいん</td>
-        <td>descender line</td>
-        <td>ディセンダは，欧文小文字のg，j，p，q，yなどの文字の，ベースラインより下に伸びている部分をいい，ディセンダラインは，ディセンダの最下端を示す，ベースラインに平行な仮想の線．</td>
-      </tr>
-      <tr id="ja-term.head">
-        <td>天</td>
-        <td>てん</td>
-        <td>head</td>
-        <td><div>a）<span class="term_listbody">本又はページの上部．</span></div>
-          <div>b）<span class="term_listbody">ページの上部の仕上り線と版面までの余白部分．</span></div>
-          <div>（JIS Z 8125）</div></td>
-      </tr>
-      <tr id="ja-term.tentsuki">
-        <td>天付き</td>
-        <td>てんつき</td>
-        <td>tentsuki</td>
-        <td><div>a）<span class="term_listbody">行頭に位置した括弧類に二分の字幅のものなどを使用して，隣接する行の行頭とそろえること．</span></div>
-          <div>b）<span class="term_listbody">段落最初の行において行頭の字下げを行わないで，隣接する行の行頭とそろえること．</span></div>
-          <div>（JIS Z 8125）</div></td>
-      </tr>
-      <tr id="ja-term.run-in-heading">
-        <td>同行見出し</td>
-        <td>どうぎょうみだし</td>
-        <td>run-in heading</td>
-        <td>見出しに続く文章を改行することなく，見出しに続けて文章を配置する形式の見出し．</td>
-      </tr>
-      <tr id="ja-term.headnote">
-        <td>頭注</td>
-        <td>とうちゅう</td>
-        <td>headnote</td>
-        <td>縦組において，基本版面内の上部に注を配置するための領域をあらかじめ設定し，その領域に本文よりも小さな文字サイズにして掲げる注．</td>
-      </tr>
-      <tr id="ja-term.touyou-kanji-table">
-        <td>当用漢字表</td>
-        <td>とうようかんじひょう</td>
-        <td>Touyou Kanji Table</td>
-        <td>1946年に制定された一般社会で使用する漢字の範囲を示す表．1850字の漢字が示されている．この表は，当用漢字音訓表，当用漢字字体表とともに常用漢字表に改められた．</td>
-      </tr>
-      <tr id="ja-term.continuous-pagination">
-        <td>通しノンブル</td>
-        <td>とおしのんぶる</td>
-        <td>continuous pagination</td>
-        <td><div>a）<span class="term_listbody">書籍の前付・本文・後付を通して一連のノンブルを付けること．</span></div>
-          <div>b）<span class="term_listbody">分冊して刊行される叢書などで，それら全体を通して一連のノンブルを付けること．また，定期刊行物での各号ごとのノンブルとは別に1年分を通したノンブルを併記すること．</span></div>
-          <div>（JIS Z 8125）</div></td>
-      </tr>
-      <tr id="ja-term.nakatsuki">
-        <td>中付き（中付きルビ）</td>
-        <td>なかつき</td>
-        <td>nakatsuki (nakatsuki-ruby)</td>
-        <td>縦組の場合は親文字の天地中央に，横組の場合は親文字の左右中央にルビを付けて配置する方法．（JIS Z 8125）</td>
-      </tr>
-      <tr id="ja-term.naka-tobira">
-        <td>中扉</td>
-        <td>なかとびら</td>
-        <td>naka-tobira</td>
-        <td>書籍の内容が大きく区分される場合に，その内容の区切りをはっきりさせるために本文中に挿入する，標題などを掲げた丁又はページ．（JIS Z 8125）</td>
-      </tr>
-      <tr id="ja-term.second-level-heading">
-        <td>中見出し</td>
-        <td>なかみだし</td>
-        <td>second level heading</td>
-        <td>大見出しと小見出しとの中間の区分に付ける標題．（JIS Z 8125）</td>
-      </tr>
-      <tr id="ja-term.base-line">
-        <td>並び線</td>
-        <td>ならびせん</td>
-        <td>base line</td>
-        <td>欧文フォントなどにおいて，フォント中の多くのグリフがその上でそろう，基本的な仮想の線．（JIS Z 8125）</td>
-      </tr>
-      <tr id="ja-term.half-em">
-        <td>二分</td>
-        <td>にぶ</td>
-        <td>half em</td>
-        <td>全角の2分の1の長さ．（JIS Z 8125）</td>
-      </tr>
-      <tr id="ja-term.half-em-space">
-        <td>二分アキ</td>
-        <td>にぶあき</td>
-        <td>half em space</td>
-        <td>二分の空き量．</td>
-      </tr>
-      <tr id="ja-term.chronological-table">
-        <td>年表</td>
-        <td>ねんぴょう</td>
-        <td>chronological table</td>
-        <td><div>歴史上の諸事件について，年代順に記載した表．年表には，社会全般の諸事件を対象とした総合年表だけでなく，目的に応じて特定の分野に限定した特殊年表がある．</div></td>
-      </tr>
-      <tr id="ja-term.chronological-history">
-        <td>年譜</td>
-        <td>ねんぷ</td>
-        <td>chronological history</td>
-        <td><div>個人（又は団体）の経歴について，年代順に記載した表．</div></td>
-      </tr>
-      <tr id="ja-term.gutter">
-        <td>のど</td>
-        <td>のど</td>
-        <td>gutter</td>
-        <td><div>a）<span class="term_listbody">本を広げたとき，中央の綴じ目がある方向．</span></div>
-          <div>b）<span class="term_listbody">中央の綴じ目と版面の余白部分．</span></div>
-          <div>c）<span class="term_listbody">本の中身と背が接する部分．</span></div>
-          <div>（JIS Z 8125）</div></td>
-      </tr>
-      <tr id="ja-term.page-number">
-        <td>ノンブル</td>
-        <td>のんぶる</td>
-        <td>page number</td>
-        <td>印刷物の各ページの順序を示すために付けてある番号．（JIS Z 8125）</td>
-      </tr>
-      <tr id="ja-term.hyphenation">
-        <td>ハイフネーション</td>
-        <td>はいふねーしょん</td>
-        <td>hyphenation</td>
-        <td>行末にかかった欧文の単語について，音節などに従い分綴可能な位置にハイフンを挿入し，2行に分割する処理．</td>
-      </tr>
-      <tr id="ja-term.running-head">
-        <td>柱</td>
-        <td>はしら</td>
-        <td>running head</td>
-        <td>各ページの版面外に記載された書名・章名・節名など．（JIS Z 8125）</td>
-      </tr>
-      <tr id="ja-term.para-ruby">
-        <td>パラルビ</td>
-        <td>ぱらるび</td>
-        <td>para-ruby</td>
-        <td>文中の一部の漢字だけにルビを付けること．（JIS Z 8125）</td>
-      </tr>
-      <tr id="ja-term.half-width">
-        <td>半角</td>
-        <td>はんかく</td>
-        <td>half-width</td>
-        <td>字幅が，全角の2分の1である文字の外枠．（JIS X 4051）</td>
-      </tr>
-      <tr id="ja-term.han-tobira">
-        <td>半扉</td>
-        <td>はんとびら</td>
-        <td>han-tobira</td>
-        <td>中扉を簡略にしたもので，裏面から本文を始める，見出しなどの標題を掲げたページ．（JIS Z 8125）</td>
-      </tr>
-      <tr id="ja-term.hanmen">
-        <td>版面</td>
-        <td>はんめん</td>
-        <td>hanmen (page content area)</td>
-        <td>本の1ページ内の，周囲の余白を除いた部分の印刷面．（参考：柱及びノンブルは版面に含めない．）（JIS Z 8125）</td>
-      </tr>
-      <tr id="ja-term.bound-on-the-left-hand-side">
-        <td>左綴じ</td>
-        <td>ひだりとじ</td>
-        <td>bound on the left-hand side</td>
-        <td>表紙の表面を正面に見た場合に，のどが左側になっている綴じ方．</td>
-      </tr>
-      <tr id="ja-term.table">
-        <td>表</td>
-        <td>ひょう</td>
-        <td>table</td>
-        <td>文字又は数字を一覧できるように，罫などで区切ったこま（小間）に配列したもの．（JIS Z 8125）</td>
-      </tr>
-      <tr id="ja-term.font">
-        <td>フォント</td>
-        <td>ふぉんと</td>
-        <td>font</td>
-        <td>ある書体によって作成された字形の集合．（JIS Z 8125）</td>
-      </tr>
-      <tr id="ja-term.subtitle">
-        <td>副題</td>
-        <td>ふくだい</td>
-        <td>subtitle</td>
-        <td>見出しに付ける副次的な標題．サブタイトルともいう．（JIS X 4051）</td>
-      </tr>
-      <tr id="ja-term.bold">
-        <td>太字</td>
-        <td>ふとじ</td>
-        <td>bold</td>
-        <td>ウェイトを大きく（字形の画線を太く）した書体．</td>
-      </tr>
-      <tr id="ja-term.line-adjustment-by-hanging-punctuation">
-        <td>ぶら下げ組</td>
-        <td>ぶらさげぐみ</td>
-        <td>line adjustment by hanging punctuation</td>
-        <td>行頭に位置した和文の句読点を1文字だけ前行の行末文字の次に指定された行長を越えて配置する方法．（JIS Z 8125）</td>
-      </tr>
-      <tr id="ja-term.furigana">
-        <td>振り仮名</td>
-        <td>ふりがな</td>
-        <td>furigana</td>
-        <td>ルビの配置位置に，仮名を使用したもの．なお，振り仮名とは，漢字の読み方を示すために，そのわきに付ける仮名という意味で，ルビと同義的に用いられてきた．この文書では“ルビ”という用語を一貫して用いる．</td>
-      </tr>
-      <tr id="ja-term.furikanji">
-        <td>振り漢字</td>
-        <td>ふりかんじ</td>
-        <td>furikanji</td>
-        <td>ルビの配置位置に，仮名ではなく，漢字を使用したもの．</td>
-      </tr>
-      <tr id="ja-term.furiwake">
-        <td>振分け</td>
-        <td>ふりわけ</td>
-        <td>furiwake</td>
-        <td>1行の中に，複数の行からなる文章を配置する方法．（JIS Z 8125）</td>
-      </tr>
-      <tr id="ja-term.proportional">
-        <td>プロポーショナル</td>
-        <td>ぷろぽーしょなる</td>
-        <td>proportional</td>
-        <td>1つのフォント中で文字の字幅が一定でなく，文字ごとに独立した字幅の値を持っていること．（JIS Z 8125）</td>
-      </tr>
-      <tr id="ja-term.break">
-        <td>（2行に）分割</td>
-        <td>ぶんかつ</td>
-        <td>break (a line)</td>
-        <td>連続した2文字について，前の文字は，その行の行末に配置し，後ろの文字は次の行の行頭に移動すること．</td>
-      </tr>
-      <tr id="ja-term.unbreakable-characters-rule">
-        <td>分割禁止</td>
-        <td>ぶんかつきんし</td>
-        <td>unbreakable characters rule</td>
-        <td>ダッシュ，リーダなど連続した同じ文字間，又は特定の文字の組の文字間では分割を禁止する規則．</td>
-      </tr>
-      <tr id="ja-term.type-picking">
-        <td>文選</td>
-        <td>ぶんせん</td>
-        <td>type-picking</td>
-        <td>原稿で指示された文字について，その活字を拾い集める作業．具体的には活字を配列してある活字ケースから文字を選び，文選箱に収める．</td>
-      </tr>
-      <tr id="ja-term.inseparable-characters-rule">
-        <td>分離禁止</td>
-        <td>ぶんりきんし</td>
-        <td>inseparable characters rule</td>
-        <td>特定の文字の組の文字間にアキを入れることを禁止すること．（JIS Z 8125）</td>
-      </tr>
-      <tr id="ja-term.parallel-note">
-        <td>並列注</td>
-        <td>へいれつちゅう</td>
-        <td>parallel-note</td>
-        <td>基本版面の設計段階であらかじめ注のための領域を確保し，その領域にページ又は見開きを単位として，その範囲にある項目に関連した注を掲げる頭注（縦組），脚注（縦組）及び傍注（横組）の総称．</td>
-      </tr>
-      <tr id="ja-term.page">
-        <td>ページ</td>
-        <td>ぺーじ</td>
-        <td>page</td>
-        <td>本などを構成する1枚の紙の片面．（JIS Z 8125）</td>
-      </tr>
-      <tr id="ja-term.solid-setting">
-        <td>ベタ組</td>
-        <td>べたぐみ</td>
-        <td>solid setting</td>
-        <td>字間を空けずに文字の外枠を接して文字を配置すること．</td>
-      </tr>
-      <tr id="ja-term.block-heading">
-        <td>別行見出し</td>
-        <td>べつぎょうみだし</td>
-        <td>block heading</td>
-        <td>本文とは別の行に配置した見出し．（JIS Z 8125）</td>
-      </tr>
-      <tr id="ja-term.independent-pagination">
-        <td>別ノンブル</td>
-        <td>べつのんぶる</td>
-        <td>independent pagination</td>
-        <td>前付ページ又は後付ページと本文ページとに別の順序付けを行うノンブルを付けること．（JIS Z 8125）</td>
-      </tr>
-      <tr id="ja-term.point">
-        <td>ポイント</td>
-        <td>ぽいんと</td>
-        <td>point</td>
-        <td>文字サイズの単位．1ポイントは0.3514mmに等しい（JIS Z 8305）．なお，ポイント以外に，文字サイズの単位に使用されている1Qは，0.25mmである．</td>
-      </tr>
-      <tr id="ja-term.bousen">
-        <td>傍線</td>
-        <td>ぼうせん</td>
-        <td>bousen (sideline)</td>
-        <td>縦組において，文字又は文字列の右又は左に引いた線．（JIS Z 8125）</td>
-      </tr>
-      <tr id="ja-term.sidenote">
-        <td>傍注</td>
-        <td>ぼうちゅう</td>
-        <td>sidenote</td>
-        <td>縦組において，見開きを単位として，そこに関連する注を左ページ（奇数ページ）の左端に本文よりも小さな文字サイズにして掲げる注．横組において，基本版面内の小口側又は右側に注を配置するための領域をあらかじめ設定し，その領域に本文よりも小さな文字サイズにして掲げる注．</td>
-      </tr>
-      <tr id="ja-term.matrix">
-        <td>母型</td>
-        <td>ぼけい</td>
-        <td>matrix</td>
-        <td>活字を鋳造する際に，字面を形成する型．</td>
-      </tr>
-      <tr id="ja-term.main-text">
-        <td>本文</td>
-        <td>ほんぶん</td>
-        <td>main text</td>
-        <td><div>a）<span class="term_listbody">書籍を構成する主要部分．通常，その前に前付，後には後付が付く．</span></div>
-          <div>b）<span class="term_listbody">図版，表，見出し，注，リードなどを除いた記事の中の主要部分．</span></div>
-          <div>c）<span class="term_listbody">ページ内の柱及びノンブルを除いた部分．</span></div>
-          <div>d）<span class="term_listbody">表紙，見返し，投げ込みなどの付属物を除いた本の中身．</span></div>
-          <div>（JIS Z 8125）</div></td>
-      </tr>
-      <tr id="ja-term.front-matter">
-        <td>前付</td>
-        <td>まえづけ</td>
-        <td>front matter</td>
-        <td>書籍の本文に先立つページで，まえがき，序文，目次，挿絵一覧，献辞など．</td>
-      </tr>
-      <tr id="ja-term.cut-in-heading">
-        <td>窓見出し</td>
-        <td>まどみだし</td>
-        <td>cut-in heading</td>
-        <td>見出しだけで1行を構成することなく，見出しの次に2行又は3行の文章を続ける見出し．</td>
-      </tr>
-      <tr id="ja-term.mawarikomi">
-        <td>回り込み</td>
-        <td>まわりこみ</td>
-        <td>mawarikomi</td>
-        <td>図版，表組などを配置するために確保した領域の字詰め方向の余白に本文を組み込むこと．（JIS Z 8125）</td>
-      </tr>
-      <tr id="ja-term.bound-on-the-right-hand-side">
-        <td>右綴じ</td>
-        <td>みぎとじ</td>
-        <td>bound on the right-hand side</td>
-        <td>表紙の表面を正面に見た場合に，のどが右側になっている綴じ方．</td>
-      </tr>
-      <tr id="ja-term.heading">
-        <td>見出し</td>
-        <td>みだし</td>
-        <td>heading</td>
-        <td><div>a）<span class="term_listbody">論文，記事などの標題．</span></div>
-          <div>b）<span class="term_listbody">本，論文，記事などの内容を区分して付けた標題．</span></div>
-          <div>（JIS Z 8125）</div></td>
-      </tr>
-      <tr id="ja-term.spread">
-        <td>見開き</td>
-        <td>みひらき</td>
-        <td>spread</td>
-        <td>本などを開いたときの両方のページ．（JIS Z 8125）</td>
-      </tr>
-      <tr id="ja-term.mincho-typeface">
-        <td>明朝体</td>
-        <td>みんちょうたい</td>
-        <td>Mincho typeface</td>
-        <td>漢字は，横線に比べて縦線が太く，起筆部と終筆部に三角形が付いている．これに調和するように設計された仮名が作られている．日本語の長文の文書では，最も使用頻度が高い．</td>
-      </tr>
-      <tr id="ja-term.table-of-contents">
-        <td>目次</td>
-        <td>もくじ</td>
-        <td>table of contents</td>
-        <td>本の内容の見出しを，書かれている順又は分野別に並べて，それぞれの該当ページ番号を示したもの．（JIS Z 8125）</td>
-      </tr>
-      <tr id="ja-term.character-size">
-        <td>文字サイズ</td>
-        <td>もじさいず</td>
-        <td>character size</td>
-        <td>文字の大きさ．通常，文字の行送り方向の外枠の長さ．</td>
-      </tr>
-      <tr id="ja-term.fixed-width">
-        <td>モノスペース</td>
-        <td>ものすぺーす</td>
-        <td>fixed-width</td>
-        <td>1つのフォントの文字の字幅がすべて等しい値を持っていること．（JIS Z 8125）</td>
-      </tr>
-      <tr id="ja-term.mono-ruby">
-        <td>モノルビ</td>
-        <td>ものるび</td>
-        <td>mono-ruby</td>
-        <td>親文字の1字ごとに対応してルビを付けて配置する方法．（JIS Z 8125）</td>
-      </tr>
-      <tr id="ja-term.punctuation-marks">
-        <td>約物</td>
-        <td>やくもの</td>
-        <td>punctuation marks</td>
-        <td>文字組版に使用する記述記号類の総称．備考：句読点・疑問符・括弧・アクセントなど．（JIS Z 8125）</td>
-      </tr>
-      <tr id="ja-term.horizontal-writing-mode">
-        <td>横組</td>
-        <td>よこぐみ</td>
-        <td>horizontal writing mode</td>
-        <td>行においては文字を水平方向に左から右へ，ページにおいて行を上から下へ，段を左から右へ配列すること．また，そのように文字が配置された状態．（JIS Z 8125）</td>
-      </tr>
-      <tr id="ja-term.label-name">
-        <td>ラベル名</td>
-        <td>らべるめい</td>
-        <td>label name</td>
-        <td>図番号，表番号，見出し番号及び柱番号において，それぞれの番号の前及び／又は後ろに付ける文字列．（JIS X 4051）</td>
-      </tr>
-      <tr id="ja-term.double-running-head-method">
-        <td>両柱方式</td>
-        <td>りょうばしらほうしき</td>
-        <td>double running head method</td>
-        <td>柱を奇数・偶数両ページに掲げること．（JIS Z 8125）</td>
-      </tr>
-      <tr id="ja-term.ruby">
-        <td>ルビ</td>
-        <td>るび</td>
-        <td>ruby</td>
-        <td>文字及び語のそばに付けて，その読み，意味などを示す小さな文字．（JIS Z 8125）“振り仮名”ともよばれることがある．</td>
-      </tr>
-      <tr id="ja-term.roman-numerals">
-        <td>ローマ数字</td>
-        <td>ろーますうじ</td>
-        <td>Roman numerals</td>
-        <td>ラテン文字の大文字又は小文字を用いて表記する数字．（JIS Z 8125）</td>
-      </tr>
-      <tr id="ja-term.japanese-and-western-mixed-text-composition">
-        <td>和欧文混植</td>
-        <td>わおうぶんこんしょく</td>
-        <td>Japanese and Western mixed text composition</td>
-        <td>和文と欧文とを併用して組版すること．</td>
-      </tr>
-      <tr id="ja-term.japanese-characters">
-        <td>和文文字</td>
-        <td>わぶんもじ</td>
-        <td>Japanese characters</td>
-        <td>日本語の文書に使用する文字．</td>
-      </tr>
-      <tr id="ja-term.warichu">
-        <td>割注</td>
-        <td>わりちゅう</td>
-        <td>warichu (inline cutting note)</td>
-        <td>本文中で，複数行に割書きした注釈．割注には，割書きを囲む括弧類を含む．（JIS Z 8125）</td>
-      </tr>
-    </tbody>
-  </table>
-</section>
+  <table class="termlist">
+      <thead>
+        <tr>
+          <th><span its-locale-filter-list="en" lang="en">Terminology</span> <span its-locale-filter-list="ja" lang="ja">用語（英語）</span></th>
+          <th><span its-locale-filter-list="en" lang="en">Japanese</span> <span its-locale-filter-list="ja" lang="ja">用語（日本語）</span></th>
+          <th>Transliteration</th>
+          <th><span its-locale-filter-list="en" lang="en">Definition</span> <span its-locale-filter-list="ja" lang="ja">定義</span></th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr id="term.back-matter">
+          <td class="xfq-term">back matter</td>
+          <td class="xfq-ja">後付</td>
+          <td class="xfq-transliteration">atozuke<br/>あとづけ</td>
+          <td class="xfq-def">
+            <p its-locale-filter-list="en" lang="en">Appendices, supplements, glossary of terms, index and/or bibliography,  and so on, appended at the end of a book.</p>
+            <p its-locale-filter-list="ja" lang="ja">書籍の巻末に付けられる付録，補遺，語彙解説，索引，文献など．</p>
+          </td>
+        </tr>
+        <tr id="term.base-characters">
+          <td class="xfq-term">base character</td>
+          <td class="xfq-ja">親文字</td>
+          <td class="xfq-transliteration">oya moji<br/>おやもじ</td>
+          <td class="xfq-def">
+            <p its-locale-filter-list="en" lang="en">A character to be annotated by ruby, ornament characters, or emphasis dots.</p>
+            <p its-locale-filter-list="ja" lang="ja">ルビ，添え字又は圏点が付けられたとき，その対象となる文字．</p>
+          </td>
+        </tr>
+        <tr id="term.base-line">
+          <td class="xfq-term">base line</td>
+          <td class="xfq-ja">並び線</td>
+          <td class="xfq-transliteration">narabi sen<br/>ならびせん</td>
+          <td class="xfq-def">
+            <p its-locale-filter-list="en" lang="en">A virtual line on which almost all glyphs in Western fonts are designed to be aligned. (JIS Z 8125)</p>
+            <p its-locale-filter-list="ja" lang="ja">欧文フォントなどにおいて，フォント中の多くのグリフがその上でそろう，基本的な仮想の線．（JIS Z 8125）</p>
+          </td>
+        </tr>
+        <tr id="term.bibliography">
+          <td class="xfq-term">bibliography</td>
+          <td class="xfq-ja">参考文献</td>
+          <td class="xfq-transliteration">sankō bunken<br/>さんこうぶんけん</td>
+          <td class="xfq-def">
+            <p its-locale-filter-list="en" lang="en">A list of works and papers related to the subjects in the text. (JIS Z 8125)</p>
+            <p its-locale-filter-list="ja" lang="ja">本文の内容に関係の深い他の著書，論文を記したもの．（JIS Z 8125）</p>
+          </td>
+        </tr>
+        <tr id="term.blank-page">
+          <td class="xfq-term">blank page</td>
+          <td class="xfq-ja">白ページ</td>
+          <td class="xfq-transliteration">shiro pēji<br/>しろぺーじ</td>
+          <td class="xfq-def">
+            <p its-locale-filter-list="en" lang="en">An empty page.</p>
+            <p its-locale-filter-list="ja" lang="ja">何も表示しないページ．</p>
+          </td>
+        </tr>
+        <tr id="term.bleed">
+          <td class="xfq-term">bleed</td>
+          <td class="xfq-ja">裁切り</td>
+          <td class="xfq-transliteration">tachikiri<br/>たちきり</td>
+          <td class="xfq-def">
+            <p its-locale-filter-list="en" lang="en">To print a picture or a tint to run off the edge of a trimmed page. (JIS Z 8125)</p>
+            <p its-locale-filter-list="ja" lang="ja">写真，平網などを断裁位置いっぱいまで印刷すること．（JIS Z 8125）</p>
+          </td>
+        </tr>
+        <tr id="term.block-direction">
+          <td class="xfq-term">block direction</td>
+          <td class="xfq-ja">行送り方向</td>
+          <td class="xfq-transliteration">gyō okuri hōkō<br/>ぎょうおくりほうこう</td>
+          <td class="xfq-def">
+            <p its-locale-filter-list="en" lang="en">The direction lines progress, one after the other. (JIS Z 8125)</p>
+            <p its-locale-filter-list="ja" lang="ja">1つの行が次の行へと続く方向．（JIS Z 8125）</p>
+          </td>
+        </tr>
+        <tr id="term.block-heading">
+          <td class="xfq-term">block heading</td>
+          <td class="xfq-ja">別行見出し</td>
+          <td class="xfq-transliteration">betsugyōmidashi<br/>べつぎょうみだし</td>
+          <td class="xfq-def">
+            <p its-locale-filter-list="en" lang="en">A kind of heading styles. The heading is set as an independent line from basic text. (JIS Z 8125)</p>
+            <p its-locale-filter-list="ja" lang="ja">本文とは別の行に配置した見出し．（JIS Z 8125）</p>
+          </td>
+        </tr>
+        <tr id="term.bold">
+          <td class="xfq-term">bold</td>
+          <td class="xfq-ja">太字</td>
+          <td class="xfq-transliteration">futoji<br/>ふとじ</td>
+          <td class="xfq-def">
+            <p its-locale-filter-list="en" lang="en">A kind of font style. Similer to bold in western typograpy.</p>
+            <p its-locale-filter-list="ja" lang="ja">ウェイトを大きく（字形の画線を太く）した書体．</p>
+          </td>
+        </tr>
+        <tr id="term.bound-on-the-left-hand-side">
+          <td class="xfq-term">bound on the left-hand side</td>
+          <td class="xfq-ja">左綴じ</td>
+          <td class="xfq-transliteration">hidari toji<br/>ひだりとじ</td>
+          <td class="xfq-def">
+            <p its-locale-filter-list="en" lang="en">Binding of a book to be opened from the left.</p>
+            <p its-locale-filter-list="ja" lang="ja">表紙の表面を正面に見た場合に，のどが左側になっている綴じ方．</p>
+          </td>
+        </tr>
+        <tr id="term.bound-on-the-right-hand-side">
+          <td class="xfq-term">bound on the right-hand side</td>
+          <td class="xfq-ja">右綴じ</td>
+          <td class="xfq-transliteration">migi toji<br/>みぎとじ</td>
+          <td class="xfq-def">
+            <p its-locale-filter-list="en" lang="en">Binding of a book to be opened from the right.</p>
+            <p its-locale-filter-list="ja" lang="ja">表紙の表面を正面に見た場合に，のどが右側になっている綴じ方．</p>
+          </td>
+        </tr>
+        <tr id="term.bousen">
+          <td class="xfq-term">bousen (sideline)</td>
+          <td class="xfq-ja">傍線</td>
+          <td class="xfq-transliteration">bōsen<br/>ぼうせん</td>
+          <td class="xfq-def">
+            <p its-locale-filter-list="en" lang="en">A line drawn by the left or right side of a character or a run of text in vertical writing mode. (JIS Z 8125)</p>
+            <p its-locale-filter-list="ja" lang="ja">縦組において，文字又は文字列の右又は左に引いた線．（JIS Z 8125）</p>
+          </td>
+        </tr>
+        <tr id="term.break">
+          <td class="xfq-term">break (a line)</td>
+          <td class="xfq-ja">（2行に）分割</td>
+          <td class="xfq-transliteration">bunkatsu<br/>ぶんかつ</td>
+          <td class="xfq-def">
+            <p its-locale-filter-list="en" lang="en">To place the first of two adjacent characters at the end of a line and the second at the head of a new line.</p>
+            <p its-locale-filter-list="ja" lang="ja">連続した2文字について，前の文字は，その行の行末に配置し，後ろの文字は次の行の行頭に移動すること．</p>
+          </td>
+        </tr>
+        <tr id="term.caption">
+          <td class="xfq-term">caption</td>
+          <td class="xfq-ja">キャプション</td>
+          <td class="xfq-transliteration">kyapushon<br/>きゃぷしょん</td>
+          <td class="xfq-def">
+            <p its-locale-filter-list="en" lang="en">A title or a short description accompanying a picture, an illustration, or a table. (JIS Z 8125)</p>
+            <p its-locale-filter-list="ja" lang="ja">写真，図版，表などにそえる標題や簡潔な説明文．（JIS Z 8125）</p>
+          </td>
+        </tr>
+        <tr id="term.cell">
+          <td class="xfq-term">cell</td>
+          <td class="xfq-ja">こま</td>
+          <td class="xfq-transliteration">koma<br/>こま</td>
+          <td class="xfq-def">
+            <p its-locale-filter-list="en" lang="en">Each element area of tables, cell.</p>
+            <p its-locale-filter-list="ja" lang="ja">表においては，罫などで小さな領域に区切るが，この隣り合う縦及び横の罫などで区切られた個々の領域．</p>
+          </td>
+        </tr>
+        <tr id="term.cell-contents">
+          <td class="xfq-term">cell contents</td>
+          <td class="xfq-ja">こま内容</td>
+          <td class="xfq-transliteration">komanaiyō<br/>こまないよう</td>
+          <td class="xfq-def">
+            <p its-locale-filter-list="en" lang="en">The content of each cell in tables. (JIS X 4051)</p>
+            <p its-locale-filter-list="ja" lang="ja">表のこまの中に表示されるもの．（JIS X 4051）</p>
+          </td>
+        </tr>
+        <tr id="term.cell-padding">
+          <td class="xfq-term">cell padding</td>
+          <td class="xfq-ja">こま余白</td>
+          <td class="xfq-transliteration">komayohaku<br/>こまよはく</td>
+          <td class="xfq-def">
+            <p its-locale-filter-list="en" lang="en">Spaces between line and cell in tables. (JIS X 4051)</p>
+            <p its-locale-filter-list="ja" lang="ja">表の罫線とこまとの間の空白領域．（JIS X 4051）</p>
+          </td>
+        </tr>
+        <tr id="term.centering">
+          <td class="xfq-term">centering</td>
+          <td class="xfq-ja">中央そろえ</td>
+          <td class="xfq-transliteration">chūō soroe<br/>ちゅうおうそろえ</td>
+          <td class="xfq-def">
+            <p its-locale-filter-list="en" lang="en">To align the center of a run of text that is shorter than a given line length to the center of a line. (JIS Z 8125)</p>
+            <p its-locale-filter-list="ja" lang="ja">文字列の中央を，行頭と行末との中央の位置に合わせること．（JIS Z 8125）</p>
+          </td>
+        </tr>
+        <tr id="term.character-advance">
+          <td class="xfq-term">character advance</td>
+          <td class="xfq-ja">字幅</td>
+          <td class="xfq-transliteration">jihaba<br/>じはば</td>
+          <td class="xfq-def">
+            <p its-locale-filter-list="en" lang="en">Size of a character frame in the inline direction, generally indicated as a ratio of the size of a full-width character, as in full-width, half-width, or quarter em width. Character advance is the width of a given character in horizontal writing-mode, while it is the height in vertical writing-mode.</p>
+            <p its-locale-filter-list="ja" lang="ja">字幅が，全角の2分の1である文字の外枠．（JIS X 4051）</p>
+          </td>
+        </tr>
+        <tr id="term.character-frame">
+          <td class="xfq-term">character frame</td>
+          <td class="xfq-ja">（文字の）外枠</td>
+          <td class="xfq-transliteration">sotowaku<br/>そとわく</td>
+          <td class="xfq-def">
+            <p its-locale-filter-list="en" lang="en">Rectangular area occupied by a character when it is set solid.</p>
+            <p its-locale-filter-list="ja" lang="ja">1つの文字が組版の際に占有する仮想的な長方形の領域．</p>
+          </td>
+        </tr>
+        <tr id="term.character-shape">
+          <td class="xfq-term">character shape</td>
+          <td class="xfq-ja">字形</td>
+          <td class="xfq-transliteration">jikei<br/></td>
+          <td class="xfq-def">
+            <p its-locale-filter-list="en" lang="en">Incarnation of a character by handwriting, printing or rendering to a computer screen. (JIS Z 8125)</p>
+            <p its-locale-filter-list="ja" lang="ja">文字について，手書き，印字，画面表示などによって実際に図形として表現したもの．（JIS Z 8125）</p>
+          </td>
+        </tr>
+        <tr id="term.character-size">
+          <td class="xfq-term">character size</td>
+          <td class="xfq-ja">文字サイズ</td>
+          <td class="xfq-transliteration">moji saizu<br/>もじさいず</td>
+          <td class="xfq-def">
+            <p its-locale-filter-list="en" lang="en">Dimensions of a character. Unless otherwise noted, it refers to the size of a character frame in the block direction.</p>
+            <p its-locale-filter-list="ja" lang="ja">文字の大きさ．通常，文字の行送り方向の外枠の長さ．</p>
+          </td>
+        </tr>
+        <tr id="term.characters-not-ending-line">
+          <td class="xfq-term">characters not ending line</td>
+          <td class="xfq-ja">行末禁則文字</td>
+          <td class="xfq-transliteration">gyōmatsu kinsoku moji<br/></td>
+          <td class="xfq-def">
+            <p its-locale-filter-list="en" lang="en">Any character for which "line-end prohibition rule" is invoked. (JIS Z 8125)</p>
+            <p its-locale-filter-list="ja" lang="ja">行末禁則の条件に該当する文字．（JIS Z 8125）</p>
+          </td>
+        </tr>
+        <tr id="term.characters-not-starting-line">
+          <td class="xfq-term">characters not starting line</td>
+          <td class="xfq-ja">行頭禁則文字</td>
+          <td class="xfq-transliteration">gyōtō kinsoku moji<br/>ぎょうとうきんそくもじ</td>
+          <td class="xfq-def">
+            <p its-locale-filter-list="en" lang="en">Any character for which "line-start prohibition rule" is invoked. (JIS Z 8125)</p>
+            <p its-locale-filter-list="ja" lang="ja">行頭禁則の条件に該当する文字．（JIS Z 8125）</p>
+          </td>
+        </tr>
+        <tr id="term.chronological-history">
+          <td class="xfq-term">chronological history</td>
+          <td class="xfq-ja">年譜</td>
+          <td class="xfq-transliteration">nenpu<br/>ねんぷ</td>
+          <td class="xfq-def">
+            <p its-locale-filter-list="en" lang="en">Chronological tabels about the histories of persons or organizations.</p>
+            <p its-locale-filter-list="ja" lang="ja">個人（又は団体）の経歴について，年代順に記載した表．</p>
+          </td>
+        </tr>
+        <tr id="term.chronological-table">
+          <td class="xfq-term">chronological table</td>
+          <td class="xfq-ja">年表</td>
+          <td class="xfq-transliteration">nenpyō<br/>ねんぴょう</td>
+          <td class="xfq-def">
+            <p its-locale-filter-list="en" lang="en">Chronologocal tables about histrical incidents. There are special types of chronological tables besides general ones, focused to specific view points and aspects.</p>
+            <p its-locale-filter-list="ja" lang="ja">歴史上の諸事件について，年代順に記載した表．年表には，社会全般の諸事件を対象とした総合年表だけでなく，目的に応じて特定の分野に限定した特殊年表がある．</p>
+          </td>
+        </tr>
+        <tr id="term.chu-boso-kei">
+          <td class="xfq-term">chu-boso-kei</td>
+          <td class="xfq-ja">中細罫</td>
+          <td class="xfq-transliteration">chūbosokei<br/>ちゅうぼそけい</td>
+          <td class="xfq-def">
+            <p its-locale-filter-list="en" lang="en">Middle width line, usually about 0.25mm.</p>
+            <p its-locale-filter-list="ja" lang="ja">0.25mm程度の太さの実線．</p>
+          </td>
+        </tr>
+        <tr id="term.column">
+          <td class="xfq-term">column</td>
+          <td class="xfq-ja">段</td>
+          <td class="xfq-transliteration">dan<br/>だん</td>
+          <td class="xfq-def">
+            <p its-locale-filter-list="en" lang="en">A partition on a page in multi-column format. (JIS Z 8125)</p>
+            <p its-locale-filter-list="ja" lang="ja">段組において，分割された1区分．（JIS Z 8125）</p>
+          </td>
+        </tr>
+        <tr id="term.column-gap">
+          <td class="xfq-term">column gap</td>
+          <td class="xfq-ja">段間</td>
+          <td class="xfq-transliteration">dankan<br/>だんかん</td>
+          <td class="xfq-def">
+            <p its-locale-filter-list="en" lang="en">Amount of space between columns on a page. (JIS Z 8125)</p>
+            <p its-locale-filter-list="ja" lang="ja">段組の段と段との間の空き．（JIS Z 8125）</p>
+          </td>
+        </tr>
+        <tr id="term.column-spanning">
+          <td class="xfq-term">column spanning</td>
+          <td class="xfq-ja">段抜き</td>
+          <td class="xfq-transliteration">dannuki<br/>だんぬき</td>
+          <td class="xfq-def">
+            <p its-locale-filter-list="en" lang="en">A setting style of illustrations, tables, etc., over hanging to multiple columns. (JIS Z 8125)</p>
+            <p its-locale-filter-list="ja" lang="ja">段組のページにおいて，見出し，図版などを複数段にまたがって配置すること．（JIS Z 8125）</p>
+          </td>
+        </tr>
+        <tr id="term.column-spanning-heading">
+          <td class="xfq-term">column spanning heading</td>
+          <td class="xfq-ja">段抜きの見出し</td>
+          <td class="xfq-transliteration">dannuki no midashi<br/>だんぬきのみだし</td>
+          <td class="xfq-def">
+            <p its-locale-filter-list="en" lang="en">Headings using multiple columns.</p>
+            <p its-locale-filter-list="ja" lang="ja">段抜きにして配置する見出し．</p>
+          </td>
+        </tr>
+        <tr id="term.composition">
+          <td class="xfq-term">composition</td>
+          <td class="xfq-ja">組版</td>
+          <td class="xfq-transliteration">kumihan<br/>くみはん</td>
+          <td class="xfq-def">
+            <p its-locale-filter-list="en" lang="en">Process of arrangement of text, figures and/or pictures, etc on a page in a desired layout (design) in preparation for printing.</p>
+            <p its-locale-filter-list="ja" lang="ja">原稿及びレイアウト（デザイン）の指定に従って，文字・図版・写真などを配置する作業の総称．</p>
+          </td>
+        </tr>
+        <tr id="term.compound-word">
+          <td class="xfq-term">compound word (jukugo)</td>
+          <td class="xfq-ja">熟語</td>
+          <td class="xfq-transliteration">jukugo<br/>じゅくご</td>
+          <td class="xfq-def">
+            <p its-locale-filter-list="en" lang="en">A combination of two or more kanji characters which makes one word.</p>
+            <p its-locale-filter-list="ja" lang="ja">2字以上の漢字が結合し，一語となったもの．</p>
+          </td>
+        </tr>
+        <tr id="term.continuous-pagination">
+          <td class="xfq-term">continuous pagination</td>
+          <td class="xfq-ja">通しノンブル</td>
+          <td class="xfq-transliteration">tōshi nonburu<br/>とおしのんぶる</td>
+          <td class="xfq-def">
+            <div its-locale-filter-list="en" lang="en">
+              <div>a) To number the pages of a book continuously across all those in the front matter, the text and the back matter.</div>
+              <div>b) To number the pages continuously across those of all books, such as a series published in separate volumes. Also to number the pages continuously across those of all issues of a periodical published in a year, aside from pagination per issue.</div>
+              <div>(JIS Z 8125)</div>
+            </div>
+            <div its-locale-filter-list="ja" lang="ja">
+                <div>a）<span class="term_listbody">書籍の前付・本文・後付を通して一連のノンブルを付けること．</span></div>
+                <div>b）<span class="term_listbody">分冊して刊行される叢書などで，それら全体を通して一連のノンブルを付けること．また，定期刊行物での各号ごとのノンブルとは別に1年分を通したノンブルを併記すること．</span></div>
+                <div>（JIS Z 8125）</div>
+            </div>
+          </td>
+        </tr>
+        <tr id="term.drop-heading">
+          <td class="xfq-term">cut-in heading</td>
+          <td class="xfq-ja">窓見出し</td>
+          <td class="xfq-transliteration">madomidashi<br/>まどみだし</td>
+          <td class="xfq-def">
+            <p its-locale-filter-list="en" lang="en">A style of headings. Headings do not occupy the full lines, but share lines area with following main text lines.</p>
+            <p its-locale-filter-list="ja" lang="ja">見出しだけで1行を構成することなく，見出しの次に2行又は3行の文章を続ける見出し．</p>
+          </td>
+        </tr>
+        <tr id="term.descender-line">
+          <td class="xfq-term">descender line</td>
+          <td class="xfq-ja">ディセンダライン</td>
+          <td class="xfq-transliteration">disenda rain<br/>でぃせんだらいん</td>
+          <td class="xfq-def">
+            <p its-locale-filter-list="en" lang="en">A descender is the part of a letter extending below the base line, as in 'g', 'j', 'p', 'q', or 'y'.  A descender line is a virtual line drawn at the bottom of descender parallel to base line.</p>
+            <p its-locale-filter-list="ja" lang="ja">ディセンダは，欧文小文字のg，j，p，q，yなどの文字の，ベースラインより下に伸びている部分をいい，ディセンダラインは，ディセンダの最下端を示す，ベースラインに平行な仮想の線．</p>
+          </td>
+        </tr>
+        <tr id="term.double-running-head-method">
+          <td class="xfq-term">double running head method</td>
+          <td class="xfq-ja">両柱方式</td>
+          <td class="xfq-transliteration">ryōbashira hōshiki<br/>りょうばしらほうしき</td>
+          <td class="xfq-def">
+            <p its-locale-filter-list="en" lang="en">A method that prints running heads on both even and odd pages. (JIS Z 8125)</p>
+            <p its-locale-filter-list="ja" lang="ja">柱を奇数・偶数両ページに掲げること．（JIS Z 8125）</p>
+          </td>
+        </tr>
+        <tr id="term.emphasis-dots">
+          <td class="xfq-term">emphasis dots</td>
+          <td class="xfq-ja">圏点</td>
+          <td class="xfq-transliteration">kenten<br/>けんてん</td>
+          <td class="xfq-def">
+            <p its-locale-filter-list="en" lang="en">Symbols attached alongside a run of base characters to emphasize them. (JIS Z 8125)</p>
+            <p its-locale-filter-list="ja" lang="ja">文字のそばに付けて注意を促したり，その部分を強調したりするしるし．（JIS Z 8125）</p>
+          </td>
+        </tr>
+        <tr id="term.endnote">
+          <td class="xfq-term">endnote</td>
+          <td class="xfq-ja">後注</td>
+          <td class="xfq-transliteration">kōchū<br/>こうちゅう</td>
+          <td class="xfq-def">
+            <p its-locale-filter-list="en" lang="en">A set of notes placed at the end of a part, chapter, section, paragraph and so on, or at the end of a book. (JIS Z 8125)</p>
+            <p its-locale-filter-list="ja" lang="ja">本文の編・章・節・段落などの区分の終わり又は巻末にまとめて入れる注釈．（JIS Z 8125）</p>
+          </td>
+        </tr>
+        <tr id="term.european-numerals">
+          <td class="xfq-term">European numerals</td>
+          <td class="xfq-ja">アラビア数字</td>
+          <td class="xfq-transliteration">arabia sūji<br/>あらびあすうじ</td>
+          <td class="xfq-def">
+            <p its-locale-filter-list="en" lang="en">Any of the symbols in [0-9] used to represent numbers. (JIS Z 8125)</p>
+            <p its-locale-filter-list="ja" lang="ja">インドに始まり，アラビアからヨーロッパに伝わった数字．（算用数字，洋数字ともいう．）（JIS Z 8125）</p>
+          </td>
+        </tr>
+        <tr id="term.even-inter-character-spacing">
+          <td class="xfq-term">even inter-character spacing</td>
+          <td class="xfq-ja">均等割り</td>
+          <td class="xfq-transliteration">kintō wari<br/>きんとうわり</td>
+          <td class="xfq-def">
+            <p its-locale-filter-list="en" lang="en">A text setting with uniform inter-character spacing per line so that each line is aligned on the same line-head and line-end. (JIS Z 8125)</p>
+            <p its-locale-filter-list="ja" lang="ja">字間を均等に空け，文字列の両端を行頭及び行末にそろえること．（JIS Z 8125）</p>
+          </td>
+        </tr>
+        <tr id="term.even-tsumegumi">
+          <td class="xfq-term">even tsumegumi</td>
+          <td class="xfq-ja">均等詰め</td>
+          <td class="xfq-transliteration">kintō zume<br/>きんとうづめ</td>
+          <td class="xfq-def">
+            <p its-locale-filter-list="en" lang="en">Adjustment of inter-character space by subtracting the same amount of space. (JIS Z 8125)</p>
+            <p its-locale-filter-list="ja" lang="ja">ベタ組より字間を一定量詰めて文字を配置する方法．（JIS Z 8125）</p>
+          </td>
+        </tr>
+        <tr id="term.face-tsumegumi">
+          <td class="xfq-term">face tsumegumi</td>
+          <td class="xfq-ja">字面詰め</td>
+          <td class="xfq-transliteration">jizura zume<br/>じづらづめ</td>
+          <td class="xfq-def">
+            <p its-locale-filter-list="en" lang="en">Adjustment of inter-character space by subtracting space to the extent that two letter faces are placed adjacent. (JIS Z 8125)</p>
+            <p its-locale-filter-list="ja" lang="ja">仮名や約物等の字面が重ならない程度まで詰めて文字を配置する方法．（JIS Z 8125）</p>
+          </td>
+        </tr>
+        <tr id="term.fixed-inter-character-spacing">
+          <td class="xfq-term">fixed inter-character spacing</td>
+          <td class="xfq-ja">アキ組</td>
+          <td class="xfq-transliteration">aki gumi<br/>あきぐみ</td>
+          <td class="xfq-def">
+            <p its-locale-filter-list="en" lang="en">A text setting with a uniform inter-character spacing. (JIS Z 8125)</p>
+            <p its-locale-filter-list="ja" lang="ja">字間に一定のアキを入れて文字を配置する方法．（JIS Z 8125）</p>
+          </td>
+        </tr>
+        <tr id="term.fixed-width">
+          <td class="xfq-term">fixed-width</td>
+          <td class="xfq-ja">モノスペース</td>
+          <td class="xfq-transliteration">monosupēsu<br/>ものすぺーす</td>
+          <td class="xfq-def">
+            <p its-locale-filter-list="en" lang="en">A characteristic of a font where the same character advance is assigned for all glyphs. (JIS Z 8125)</p>
+            <p its-locale-filter-list="ja" lang="ja">1つのフォントの文字の字幅がすべて等しい値を持っていること．（JIS Z 8125）</p>
+          </td>
+        </tr>
+        <tr id="term.font">
+          <td class="xfq-term">font</td>
+          <td class="xfq-ja">フォント</td>
+          <td class="xfq-transliteration">fonto<br/>ふぉんと</td>
+          <td class="xfq-def">
+            <p its-locale-filter-list="en" lang="en">A set of character glyphs of a given typeface. (JIS Z 8125)</p>
+            <p its-locale-filter-list="ja" lang="ja">ある書体によって作成された字形の集合．（JIS Z 8125）</p>
+          </td>
+        </tr>
+        <tr id="term.foot">
+            <td class="xfq-term">foot</td>
+            <td class="xfq-ja">地</td>
+            <td class="xfq-transliteration">chi<br/>ち</td>
+            <td class="xfq-def">
+              <div its-locale-filter-list="en" lang="en">
+                  <div>a) The bottom part of a book or a page.</div>
+                  <div>b) The bottom margin between the edge of a trimmed page and the hanmen (text area)</div>
+                  <div>(JIS Z 8125)</div>
+              </div>
+              <div its-locale-filter-list="ja" lang="ja">
+                  <div>a）<span class="term_listbody">本又はページの下部．</span></div>
+                  <div>b）<span class="term_listbody">ページの下部の仕上り線と版面までの余白部分．</span></div>
+                  <div>（JIS Z 8125）</div>
+              </div>
+            </td>
+          </tr>
+          <tr id="term.footnote">
+            <td class="xfq-term">footnote</td>
+            <td class="xfq-ja">脚注</td>
+            <td class="xfq-transliteration">kyakuchū<br/>きゃくちゅう</td>
+            <td class="xfq-def">
+              <p its-locale-filter-list="en" lang="en">A note in a smaller face than that of main text, placed at the bottom of a page. (JIS Z 8125)</p>
+              <p its-locale-filter-list="ja" lang="ja">ページの下部に，本文よりも小さな文字で組まれた注釈．（JIS Z 8125）</p>
+            </td>
+          </tr>
+          <tr id="term.fore-edge">
+            <td class="xfq-term">fore-edge</td>
+            <td class="xfq-ja">小口</td>
+            <td class="xfq-transliteration">koguchi<br/>こぐち</td>
+            <td class="xfq-def">
+              <div its-locale-filter-list="en" lang="en">
+                  <div>a) The three front trimmed edges of pages in a book.</div>
+                  <div>b) The opposite sides of the gutter in a book.</div>
+                  <div>(JIS Z 8125)</div>
+              </div>
+              <div its-locale-filter-list="ja" lang="ja">
+                  <div>a）<span class="term_listbody">本のページの綴じていない三方の切り口．</span></div>
+                  <div>b）<span class="term_listbody">のどの反対側．</span></div>
+                  <div>（JIS Z 8125）</div>
+              </div>
+            </td>
+          </tr>
+          <tr id="term.front-matter">
+            <td class="xfq-term">front matter</td>
+            <td class="xfq-ja">前付</td>
+            <td class="xfq-transliteration">maezuke<br/>まえづけ</td>
+            <td class="xfq-def">
+              <p its-locale-filter-list="en" lang="en">The first part of a book followed by the text, usually consisting of a forward, preface, table of contents, list of illustrations, acknowledgement and so on. </p>
+              <p its-locale-filter-list="ja" lang="ja">書籍の本文に先立つページで，まえがき，序文，目次，挿絵一覧，献辞など．</p>
+            </td>
+          </tr>
+          <tr id="term.full-width">
+            <td class="xfq-term">full-width</td>
+            <td class="xfq-ja">全角</td>
+            <td class="xfq-transliteration">zenkaku<br/>ぜんかく</td>
+            <td class="xfq-def">
+              <div its-locale-filter-list="en" lang="en">
+                  <div>a) Relative index for the length which is equal to a given character size.</div>
+                  <div>b) Character frame which character advance is equal to the amount referred to as a). A full-width character frame is  square in shape by definition.</div>
+              </div>
+              <div its-locale-filter-list="ja" lang="ja">
+                  <div>a）<span class="term_listbody">文字サイズに等しい長さの相対単位．</span></div>
+                  <div>b）<span class="term_listbody">字幅がaである文字の外枠．この場合，文字の外枠は正方形になる．</span></div>
+              </div>
+            </td>
+          </tr>
+          <tr id="term.furigana">
+            <td class="xfq-term">furigana</td>
+            <td class="xfq-ja">振り仮名</td>
+            <td class="xfq-transliteration">furigana<br/></td>
+            <td class="xfq-def">
+              <p its-locale-filter-list="en" lang="en">A method of ruby annotation using kana characters to indicate how to read kanji characters. This term derives from a Japanese verb "furu (to attach alongside)" and "kana", and has been used synonymously with "ruby". This document prefers to use the term "ruby".</p>
+              <p its-locale-filter-list="ja" lang="ja">ルビの配置位置に，仮名を使用したもの．なお，振り仮名とは，漢字の読み方を示すために，そのわきに付ける仮名という意味で，ルビと同義的に用いられてきた．この文書では“ルビ”という用語を一貫して用いる．</p>
+            </td>
+          </tr>
+          <tr id="term.furikanji">
+            <td class="xfq-term">furikanji</td>
+            <td class="xfq-ja">振り漢字</td>
+            <td class="xfq-transliteration">furikanji<br/>ふりがな</td>
+            <td class="xfq-def">
+              <p its-locale-filter-list="en" lang="en">A method of ruby annotation using Kanji characters for ruby instead of kana characters.</p>
+              <p its-locale-filter-list="ja" lang="ja">ルビの配置位置に，仮名ではなく，漢字を使用したもの．</p>
+            </td>
+          </tr>
+          <tr id="term.furiwake">
+            <td class="xfq-term">furiwake</td>
+            <td class="xfq-ja">振分け</td>
+            <td class="xfq-transliteration">furiwake<br/>ふりわけ</td>
+            <td class="xfq-def">
+              <p its-locale-filter-list="en" lang="en">A method of placing multiple runs of text in a line. (JIS Z 8125)</p>
+              <p its-locale-filter-list="ja" lang="ja">1行の中に，複数の行からなる文章を配置する方法．（JIS Z 8125）</p>
+            </td>
+          </tr>
+          <tr id="term.general-ruby">
+            <td class="xfq-term">general-ruby</td>
+            <td class="xfq-ja">総ルビ</td>
+            <td class="xfq-transliteration">sō rubi<br/>そうるび</td>
+            <td class="xfq-def">
+              <p its-locale-filter-list="en" lang="en">A method of ruby annotation that attaches ruby text for all Kanji characters in the text. (JIS Z 8125)</p>
+              <p its-locale-filter-list="ja" lang="ja">文中のすべての漢字にルビを付けること．（JIS Z 8125）</p>
+            </td>
+          </tr>
+          <tr id="term.group-ruby">
+            <td class="xfq-term">group-ruby</td>
+            <td class="xfq-ja">グループルビ</td>
+            <td class="xfq-transliteration">gurūpu rubi<br/>ぐるーぷるび</td>
+            <td class="xfq-def">
+              <p its-locale-filter-list="en" lang="en">A method of ruby character distribution such that the length of ruby text matches to that of the base text by giving the same adjusted amount of space between ruby characters.</p>
+              <p its-locale-filter-list="ja" lang="ja">複数の親文字で構成される語全体に掛かるように均等間隔にルビを付けて配置する方法．</p>
+            </td>
+          </tr>
+          <tr id="term.gutter">
+            <td class="xfq-term">gutter</td>
+            <td class="xfq-ja">のど</td>
+            <td class="xfq-transliteration">nodo<br/>のど</td>
+            <td class="xfq-def">
+              <div its-locale-filter-list="en" lang="en">
+                  <div>a) The binding side of a spread of a book.</div>
+                  <div>b) The margin between the binding edge of a book and the hanmen (text area).</div>
+                  <div>c) The part of a book where all pages are bound together to the book spine.</div>
+                  <div>(JIS Z 8125)</div>
+              </div>
+              <div its-locale-filter-list="ja" lang="ja">
+                  <div>a）<span class="term_listbody">本を広げたとき，中央の綴じ目がある方向．</span></div>
+                  <div>b）<span class="term_listbody">中央の綴じ目と版面の余白部分．</span></div>
+                  <div>c）<span class="term_listbody">本の中身と背が接する部分．</span></div>
+                  <div>（JIS Z 8125）</div>
+              </div>
+            </td>
+          </tr>
+          <tr id="term.gyodori">
+            <td class="xfq-term">gyodori</td>
+            <td class="xfq-ja">行取り</td>
+            <td class="xfq-transliteration">gyōdori<br/>ぎょうどり</td>
+            <td class="xfq-def">
+              <p its-locale-filter-list="en" lang="en">To keep block direction area for headings and so on, along with line units in kihon-hanmen. The width of the gyodori space is calculated with following fomula: line width × number of lines + line gap × (number of lines − 1). However, deceptively, in middle of page or column, the line gaps before and after seem to be added to the gyodori space, and in the start of page or column, the line gap after seems to be added to the gyodori space.</p>
+              <p its-locale-filter-list="ja" lang="ja">見出しなどを配置する領域の行送り方向の大きさを行単位で確保すること．この場合，行送り方向の見出しの占めるスペースは，“行の幅×行数＋行間×（行数－1）”となる．しかし，見た目には，ページ（又は段）の途中に見出しを配置する場合は，そのスペースの前及び後ろの行間が加わり，ページ（又は段）の先頭に見出しを配置する場合は，そのスペースの後ろの行間が加わった大きさとなる．</p>
+            </td>
+          </tr>
+          <tr id="term.half-em">
+            <td class="xfq-term">half em</td>
+            <td class="xfq-ja">二分</td>
+            <td class="xfq-transliteration">nibu<br/>にぶ</td>
+            <td class="xfq-def">
+              <p its-locale-filter-list="en" lang="en">Half of the full-width size. (JIS Z 8125)</p>
+              <p its-locale-filter-list="ja" lang="ja">全角の2分の1の長さ．（JIS Z 8125）</p>
+            </td>
+          </tr>
+          <tr id="term.half-em-space">
+            <td class="xfq-term">half em space</td>
+            <td class="xfq-ja">二分アキ</td>
+            <td class="xfq-transliteration">nibu aki<br/>にぶあき</td>
+            <td class="xfq-def">
+              <p its-locale-filter-list="en" lang="en">Amount of space that is half size of em space.</p>
+              <p its-locale-filter-list="ja" lang="ja">二分の空き量．</p>
+            </td>
+          </tr>
+          <tr id="term.half-width">
+            <td class="xfq-term">half-width</td>
+            <td class="xfq-ja">半角</td>
+            <td class="xfq-transliteration">hankaku<br/>はんかく</td>
+            <td class="xfq-def">
+              <p its-locale-filter-list="en" lang="en">Character frame which has a character advance of a half em.</p>
+              <p its-locale-filter-list="ja" lang="ja">字幅が，全角の2分の1である文字の外枠．（JIS X 4051）</p>
+            </td>
+          </tr>
+          <tr id="term.han-tobira">
+            <td class="xfq-term">han-tobira</td>
+            <td class="xfq-ja">半扉</td>
+            <td class="xfq-transliteration">hantobira<br/>はんとびら</td>
+            <td class="xfq-def">
+              <p its-locale-filter-list="en" lang="en">A simplified version of naka-tobira, the verso side of which text of the new part starts. (JIS Z 8125)</p>
+              <p its-locale-filter-list="ja" lang="ja">中扉を簡略にしたもので，裏面から本文を始める，見出しなどの標題を掲げたページ．（JIS Z 8125）</p>
+            </td>
+          </tr>
+          <tr id="term.hanmen">
+            <td class="xfq-term">hanmen (page content area)</td>
+            <td class="xfq-ja">版面</td>
+            <td class="xfq-transliteration">hanmen<br/>はんめん</td>
+            <td class="xfq-def">
+              <p its-locale-filter-list="en" lang="en">Actual printed area in a page excluding the margins. (note: Running heads and page numbers are not part of hanmen.) (JIS Z 8125)</p>
+              <p its-locale-filter-list="ja" lang="ja">本の1ページ内の，周囲の余白を除いた部分の印刷面．（参考：柱及びノンブルは版面に含めない．）（JIS Z 8125）</p>
+            </td>
+          </tr>
+          <tr id="term.head">
+            <td class="xfq-term">head</td>
+            <td class="xfq-ja">天</td>
+            <td class="xfq-transliteration">ten<br/>てん</td>
+            <td class="xfq-def">
+              <div its-locale-filter-list="en" lang="en">
+                  <div>a) The top part of a book or a page.</div>
+                  <div>b) The top margin between the top edge of a trimmed page and the hanmen (text area)</div>
+                  <div>(JIS Z 8125)</div>
+              </div>
+              <div its-locale-filter-list="ja" lang="ja">
+                  <div>a）<span class="term_listbody">本又はページの上部．</span></div>
+                  <div>b）<span class="term_listbody">ページの上部の仕上り線と版面までの余白部分．</span></div>
+                  <div>（JIS Z 8125）</div>
+              </div>
+            </td>
+          </tr>
+          <tr id="term.heading">
+            <td class="xfq-term">heading</td>
+            <td class="xfq-ja">見出し</td>
+            <td class="xfq-transliteration">midashi<br/>みだし</td>
+            <td class="xfq-def">
+              <div its-locale-filter-list="en" lang="en">
+                  <div>a) A title of a paper or an article.</div>
+                  <div>b) A title for each section of a book, paper or article.</div>
+                  <div>(JIS Z 8125)</div>
+              </div>
+              <div its-locale-filter-list="ja" lang="ja">
+                  <div>a）<span class="term_listbody">論文，記事などの標題．</span></div>
+                  <div>b）<span class="term_listbody">本，論文，記事などの内容を区分して付けた標題．</span></div>
+                  <div>（JIS Z 8125）</div>
+              </div>
+            </td>
+          </tr>
+          <tr id="term.headnote">
+            <td class="xfq-term">headnote</td>
+            <td class="xfq-ja">頭注</td>
+            <td class="xfq-transliteration">tōchū<br/>とうちゅう</td>
+            <td class="xfq-def">
+              <p its-locale-filter-list="en" lang="en">A kind of notes in vertical writing style, head area in kihon-hanmen is kept beforehand, and notes are set with smaller size font than main text.</p>
+              <p its-locale-filter-list="ja" lang="ja">縦組において，基本版面内の上部に注を配置するための領域をあらかじめ設定し，その領域に本文よりも小さな文字サイズにして掲げる注．</p>
+            </td>
+          </tr>
+          <tr id="term.horizontal-writing-mode">
+            <td class="xfq-term">horizontal writing mode</td>
+            <td class="xfq-ja">横組</td>
+            <td class="xfq-transliteration">yokogumi<br/>よこぐみ</td>
+            <td class="xfq-def">
+              <p its-locale-filter-list="en" lang="en">The process or the result of arranging characters on a line from left to right, of lines on a page from top to bottom, and/or of columns on a page from left to right. (JIS Z 8125)</p>
+              <p its-locale-filter-list="ja" lang="ja">行においては文字を水平方向に左から右へ，ページにおいて行を上から下へ，段を左から右へ配列すること．また，そのように文字が配置された状態．（JIS Z 8125）</p>
+            </td>
+          </tr>
+          <tr id="term.hyphenation">
+            <td class="xfq-term">hyphenation</td>
+            <td class="xfq-ja">ハイフネーション</td>
+            <td class="xfq-transliteration">haifunēshon<br/>はいふねーしょん</td>
+            <td class="xfq-def">
+              <p its-locale-filter-list="en" lang="en">A method of breaking a line by dividing a Western word at the end of a line and adding a hyphen  at the end of the first half of the syllable. </p>
+              <p its-locale-filter-list="ja" lang="ja">行末にかかった欧文の単語について，音節などに従い分綴可能な位置にハイフンを挿入し，2行に分割する処理．</p>
+            </td>
+          </tr>
+          <tr id="term.ideographic-numerals">
+            <td class="xfq-term">ideographic numerals</td>
+            <td class="xfq-ja">漢数字</td>
+            <td class="xfq-transliteration">kansūji<br/>かんすうじ</td>
+            <td class="xfq-def">
+              <p its-locale-filter-list="en" lang="en">Ideographic characters representing numbers.</p>
+              <p its-locale-filter-list="ja" lang="ja">漢字の一二三…十などを用いて表す数字．</p>
+            </td>
+          </tr>
+          <tr id="term.illustrations">
+            <td class="xfq-term">illustrations</td>
+            <td class="xfq-ja">図版</td>
+            <td class="xfq-transliteration">zuhan<br/>ずはん</td>
+            <td class="xfq-def">
+              <p its-locale-filter-list="en" lang="en">A general term referring to a diagram, chart, cut, figure, picture and the like, to be used for printed materials.</p>
+              <p its-locale-filter-list="ja" lang="ja">印刷物の中に掲げる図，グラフ，カット，イラストレーション，写真などの総称．</p>
+            </td>
+          </tr>
+          <tr id="term.independent-pagination">
+            <td class="xfq-term">independent pagination</td>
+            <td class="xfq-ja">別ノンブル</td>
+            <td class="xfq-transliteration">betsu nonburu<br/>べつのんぶる</td>
+            <td class="xfq-def">
+              <p its-locale-filter-list="en" lang="en">To number the pages of the front matter, the text and the back matter independently. (JIS Z 8125)</p>
+              <p its-locale-filter-list="ja" lang="ja">前付ページ又は後付ページと本文ページとに別の順序付けを行うノンブルを付けること．（JIS Z 8125）</p>
+            </td>
+          </tr>
+          <tr id="term.index">
+            <td class="xfq-term">index</td>
+            <td class="xfq-ja">索引</td>
+            <td class="xfq-transliteration">sakuin<br/>さくいん</td>
+            <td class="xfq-def">
+              <p its-locale-filter-list="en" lang="en">A list of terms or subjects with page numbers for where they are referred to in a single or multiple volumes of a book. (JIS Z 8125)</p>
+              <p its-locale-filter-list="ja" lang="ja">1冊又は複数冊からなる本の中の語句，事項などを抜き出して配列し，それぞれの該当ページ番号を示したもの．（JIS Z 8125）</p>
+            </td>
+          </tr>
+          <tr id="term.inline-direction">
+            <td class="xfq-term">inline direction</td>
+            <td class="xfq-ja">字詰め方向</td>
+            <td class="xfq-transliteration">jizume hōkō<br/>じづめほうこう</td>
+            <td class="xfq-def">
+              <p its-locale-filter-list="en" lang="en">Text direction in a line. (JIS Z 8125)</p>
+              <p its-locale-filter-list="ja" lang="ja">1行の中で，1つの文字から次の文字へと続く方向．（JIS Z 8125）</p>
+            </td>
+          </tr>
+          <tr id="term.inseparable-characters-rule">
+            <td class="xfq-term">inseparable characters rule</td>
+            <td class="xfq-ja">分離禁止</td>
+            <td class="xfq-transliteration">bunri kinshi<br/>ぶんりきんし</td>
+            <td class="xfq-def">
+              <p its-locale-filter-list="en" lang="en">A line adjustment rule that prohibits inserting any space between specific combinations of characters. (JIS Z 8125)</p>
+              <p its-locale-filter-list="ja" lang="ja">特定の文字の組の文字間にアキを入れることを禁止すること．（JIS Z 8125）</p>
+            </td>
+          </tr>
+          <tr id="term.inter-character-space">
+            <td class="xfq-term">inter-character space</td>
+            <td class="xfq-ja">字間</td>
+            <td class="xfq-transliteration">jikan<br/>じかん</td>
+            <td class="xfq-def">
+              <p its-locale-filter-list="en" lang="en">Amount of space between two adjacent character frames on the same line.</p>
+              <p its-locale-filter-list="ja" lang="ja">同一行の隣接する2つの文字の外枠の間隔．</p>
+            </td>
+          </tr>
+          <tr id="term.itemization">
+            <td class="xfq-term">itemization</td>
+            <td class="xfq-ja">箇条書き</td>
+            <td class="xfq-transliteration">kajō gaki<br/>かじょうがき</td>
+            <td class="xfq-def">
+              <p its-locale-filter-list="en" lang="en">To list ordered or unordered items one under the other. (JIS Z 8125)</p>
+              <p its-locale-filter-list="ja" lang="ja">順序付き，又は順序を明示することなく項目を列挙すること．（JIS Z 8125）</p>
+            </td>
+          </tr>
+          <tr id="term.japanese-and-western-mixed-text-composition">
+            <td class="xfq-term">Japanese and Western mixed text composition</td>
+            <td class="xfq-ja">和欧文混植</td>
+            <td class="xfq-transliteration">waō konshoku<br/>わおうぶんこんしょく</td>
+            <td class="xfq-def">
+              <p its-locale-filter-list="en" lang="en">To mix Japanese text and Western text in the same composition.</p>
+              <p its-locale-filter-list="ja" lang="ja">和文と欧文とを併用して組版すること．</p>
+            </td>
+          </tr>
+          <tr id="term.japanese-characters">
+            <td class="xfq-term">Japanese characters</td>
+            <td class="xfq-ja">和文文字</td>
+            <td class="xfq-transliteration">wabun moji<br/>わぶんもじ</td>
+            <td class="xfq-def">
+              <p its-locale-filter-list="en" lang="en">Characters used to compose Japanese text.</p>
+              <p its-locale-filter-list="ja" lang="ja">日本語の文書に使用する文字．</p>
+            </td>
+          </tr>
+          <tr id="term.japanese-gothic-face">
+            <td class="xfq-term">Japanese gothic face</td>
+            <td class="xfq-ja">ゴシック体</td>
+            <td class="xfq-transliteration">goshikku tai<br/>ごしっくたい</td>
+            <td class="xfq-def">
+              <p its-locale-filter-list="en" lang="en">A Japanese typeface, with strokes almost the same in thickness, and no special ornament on a stroke such as a triangular element commonly seen in the Mincho typeface. Used for text emphasis and/or headings.</p>
+              <p its-locale-filter-list="ja" lang="ja">文字の線がほぼ同じ幅を持った和文書体で，明朝体のように三角形のうろこが付いていない．強調する部分や見出しなどに用いる．</p>
+            </td>
+          </tr>
+          <tr id="term.jidori">
+            <td class="xfq-term">jidori</td>
+            <td class="xfq-ja">字取り</td>
+            <td class="xfq-transliteration">jidori<br/>じどり</td>
+            <td class="xfq-def">
+              <p its-locale-filter-list="en" lang="en">A method of aligning a run of text to both edges which is specified by a position to start and the length calculated by a specified number of a given size of characters. (JIS Z 8125)</p>
+              <p its-locale-filter-list="ja" lang="ja">使用文字サイズの倍数で指定した長さの両端に文字列の先頭と最後尾をそろえて文字を配置する方法．（JIS Z 8125）</p>
+            </td>
+          </tr>
+          <tr id="term.jouyou-kanji-table">
+            <td class="xfq-term">Jouyou Kanji Table</td>
+            <td class="xfq-ja">常用漢字表</td>
+            <td class="xfq-transliteration">jōyō kanji hyō<br/>じょうようかんじひょう</td>
+            <td class="xfq-def">
+              <p its-locale-filter-list="en" lang="en">The official list of Kanji characters "for general use in society. such as in legal and official documents, newspapers, magazines, broadcasting and the like". It was established in 1981 as a reference guide for people in composing contemporary Japanese. It listed 1,945 of Kanji characters together with their orthographic shapes, Japanese native reading (Kun), Chinese derived reading (On) and other useful information.</p>
+              <p its-locale-filter-list="ja" lang="ja">1981年に制定された一般の社会生活において，現代の国語を書き表す場合の漢字使用の目安を示す表．1945字の漢字，その音訓，字体などが示されている．</p>
+            </td>
+          </tr>
+          <tr id="term.jukugo-ruby">
+            <td class="xfq-term">jukugo-ruby</td>
+            <td class="xfq-ja">熟語ルビ</td>
+            <td class="xfq-transliteration">jukugo rubi<br/>じゅくごるび</td>
+            <td class="xfq-def">
+              <p its-locale-filter-list="en" lang="en">A method of ruby character distribution determined by two functions, one is to provide reading for each Kanji character, the other is to give a united appearance attached to a word.</p>
+              <p its-locale-filter-list="ja" lang="ja">熟語の個々の漢字の読みと熟語としてのまとまりの2つを考慮して配置位置を決めるルビの配置方法．</p>
+            </td>
+          </tr>
+          <tr id="term.kabe">
+            <td class="xfq-term">kabe</td>
+            <td class="xfq-ja">かべ</td>
+            <td class="xfq-transliteration">kabe<br/>かべ</td>
+            <td class="xfq-def">
+              <p its-locale-filter-list="en" lang="en">Main text is bounced before the dannuki headings, illustrations, tables, etc., like balls and walls.</p>
+              <p its-locale-filter-list="ja" lang="ja">段組において，版面の中に配置した段抜きの見出し・図版・表組などを壁にたとえ，その手前で文章の行の流れを折り返すこと．</p>
+            </td>
+          </tr>
+          <tr id="term.kanbun-composition">
+            <td class="xfq-term">kanbun composition</td>
+            <td class="xfq-ja">漢文</td>
+            <td class="xfq-transliteration">kanbun<br/>かんぶん</td>
+            <td class="xfq-def">
+              <p its-locale-filter-list="en" lang="en">Chinese classic text (or  text in the same style) with various auxiliary symbols so that it can be read as Japanese text.</p>
+              <p its-locale-filter-list="ja" lang="ja">中国の古典文（又はそれにならった文体の文）について，日本語の文として読むことが可能になるように，読むための様々な補助記号を付けた文．</p>
+            </td>
+          </tr>
+          <tr id="term.katatsuki">
+            <td class="xfq-term">katatsuki (katatsuki-ruby)</td>
+            <td class="xfq-ja">肩付き（肩付きルビ）</td>
+            <td class="xfq-transliteration">katatsuki (katatsuki rubi)<br/>かたつき</td>
+            <td class="xfq-def">
+              <p its-locale-filter-list="en" lang="en">A method of attaching ruby at the upper right of each base character. (JIS Z 8125)</p>
+              <p its-locale-filter-list="ja" lang="ja">縦組において，ルビを親文字の右肩に付けて配置する方法．（JIS Z 8125）</p>
+            </td>
+          </tr>
+          <tr id="term.kihon-hanmen">
+            <td class="xfq-term">kihon-hanmen</td>
+            <td class="xfq-ja">基本版面</td>
+            <td class="xfq-transliteration">kihon hanmen<br/>きほんはんめん</td>
+            <td class="xfq-def">
+              <p its-locale-filter-list="en" lang="en">The default dimensions of the main area of a typeset page specified by text direction, number of columns, character size, number of characters in a line, number of lines in a column, inter-line spacing and inter-column spacing. (JIS X 4051)</p>
+              <p its-locale-filter-list="ja" lang="ja">本の基本として設計される版面体裁．組方向，段数，文字サイズ，字詰め数，行数，行間及び段間で指定する．（JIS X 4051）</p>
+            </td>
+          </tr>
+          <tr id="term.label-name">
+            <td class="xfq-term">label name</td>
+            <td class="xfq-ja">ラベル名</td>
+            <td class="xfq-transliteration">raberumei<br/>らべるめい</td>
+            <td class="xfq-def">
+              <p its-locale-filter-list="en" lang="en">Text following or followed by numbers for illustrations, tables, headings and running headings. (JIS X 4051)</p>
+              <p its-locale-filter-list="ja" lang="ja">図番号，表番号，見出し番号及び柱番号において，それぞれの番号の前及び／又は後ろに付ける文字列．（JIS X 4051）</p>
+            </td>
+          </tr>
+          <tr id="term.letter-face">
+            <td class="xfq-term">letter face</td>
+            <td class="xfq-ja">字面</td>
+            <td class="xfq-transliteration">jizura<br/>じづら</td>
+            <td class="xfq-def">
+              <p its-locale-filter-list="en" lang="en">Area in which glyph is drawn. (JIS Z 8125)</p>
+              <p its-locale-filter-list="ja" lang="ja">字形の，実際に表示される領域．（JIS Z 8125）</p>
+            </td>
+          </tr>
+          <tr id="term.letterpress-printing">
+            <td class="xfq-term">letterpress printing</td>
+            <td class="xfq-ja">活字組版</td>
+            <td class="xfq-transliteration">katsuji kumihan<br/>かつじくみはん</td>
+            <td class="xfq-def">
+              <p its-locale-filter-list="en" lang="en">The traditional printing method using movable type.</p>
+              <p its-locale-filter-list="ja" lang="ja">可動式の活字，その他の材料を用いた伝統的な組版．</p>
+            </td>
+          </tr>
+          <tr id="term.line-adjustment">
+            <td class="xfq-term">line adjustment</td>
+            <td class="xfq-ja">行の調整処理</td>
+            <td class="xfq-transliteration">gyō no chōsei shori<br/>ぎょうのちょうせいしょり</td>
+            <td class="xfq-def">
+              <p its-locale-filter-list="en" lang="en">A method of aligning both edges of all lines to be the same given length by removing or adding adjustable spaces.</p>
+              <p its-locale-filter-list="ja" lang="ja">指定された行長にするために，字間を詰める又は空ける処理．</p>
+            </td>
+          </tr>
+          <tr id="term.line-adjustment-by-hanging-punctuation">
+            <td class="xfq-term">line adjustment by hanging punctuation</td>
+            <td class="xfq-ja">ぶら下げ組</td>
+            <td class="xfq-transliteration">burasage gumi<br/>ぶらさげぐみ</td>
+            <td class="xfq-def">
+              <p its-locale-filter-list="en" lang="en">A line breaking rule to avoid commas or full stops at a line head (which is prohibited in Japanese typography) by taking them back to the end of the previous line beyond the specified line length. (JIS Z 8125)</p>
+              <p its-locale-filter-list="ja" lang="ja">行頭に位置した和文の句読点を1文字だけ前行の行末文字の次に指定された行長を越えて配置する方法．（JIS Z 8125）</p>
+            </td>
+          </tr>
+          <tr id="term.line-adjustment-by-inter-character-space-expansion">
+            <td class="xfq-term">line adjustment by inter-character space expansion</td>
+            <td class="xfq-ja">追出し処理</td>
+            <td class="xfq-transliteration">oidashi shori<br/>おいだししょり</td>
+            <td class="xfq-def">
+              <p its-locale-filter-list="en" lang="en">A line breaking rule that aligns both edges of a line by expanding inter-character spaces. (JIS Z 8125).</p>
+              <p its-locale-filter-list="ja" lang="ja">禁則処理の1つの方法であって，字間を広げて行頭行末そろえをすること（JIS Z 8125）．行頭行末そろえとは，各行の最初の文字を行頭にそろえ，かつ各行の最後の文字を行末にそろえて配置する方法（JIS Z 8125）．</p>
+            </td>
+          </tr>
+          <tr id="term.line-adjustment-by-inter-character-space-reduction">
+            <td class="xfq-term">line adjustment by inter-character space reduction</td>
+            <td class="xfq-ja">追込み処理</td>
+            <td class="xfq-transliteration">oikomi shori<br/>おいこみしょり</td>
+            <td class="xfq-def">
+              <p its-locale-filter-list="en" lang="en">A line breaking rule that aligns both edges of a line by removing adjustable spaces such as conditional spaces for punctuation marks. (JIS Z 8125).</p>
+              <p its-locale-filter-list="ja" lang="ja">禁則処理の1つの方法であって，約物の前後などを詰めて行頭行末そろえをすること（JIS Z 8125）．行頭行末そろえとは，各行の最初の文字を行頭にそろえ，かつ各行の最後の文字を行末にそろえて配置する方法（JIS Z 8125）．</p>
+            </td>
+          </tr>
+          <tr id="term.line-breaking-rules">
+            <td class="xfq-term">line breaking rules</td>
+            <td class="xfq-ja">禁則処理</td>
+            <td class="xfq-transliteration">kinsoku shori<br/>きんそくしょり</td>
+            <td class="xfq-def">
+              <p its-locale-filter-list="en" lang="en">A set of rules to avoid prohibited layout in Japanese typography, such as "line-start prohibition rule", "line-end prohibition rule", inseparable or unbreakable character sequences and so on. (JIS Z 8125)</p>
+              <p its-locale-filter-list="ja" lang="ja">行頭禁則，行末禁則，分離（分割）禁止などの禁則を避けるために行われる処理．（JIS Z 8125）</p>
+            </td>
+          </tr>
+          <tr id="term.line-end">
+            <td class="xfq-term">line end</td>
+            <td class="xfq-ja">行末</td>
+            <td class="xfq-transliteration">gyōmatsu<br/>ぎょうまつ</td>
+            <td class="xfq-def">
+              <p its-locale-filter-list="en" lang="en">The position at which a line ends. (JIS Z 8125)</p>
+              <p its-locale-filter-list="ja" lang="ja">1つの行の終わる位置．（JIS Z 8125）</p>
+            </td>
+          </tr>
+          <tr id="term.line-end-alignment">
+            <td class="xfq-term">line end alignment</td>
+            <td class="xfq-ja">行末そろえ</td>
+            <td class="xfq-transliteration">gyōmatsu soroe<br/>ぎょうまつそろえ</td>
+            <td class="xfq-def">
+              <p its-locale-filter-list="en" lang="en">To align a run of text to the line end. (JIS Z 8125)</p>
+              <p its-locale-filter-list="ja" lang="ja">文字列の最後の文字を行末の位置に合わせること．（JIS Z 8125）</p>
+            </td>
+          </tr>
+          <tr id="term.line-end-indent">
+            <td class="xfq-term">line end indent</td>
+            <td class="xfq-ja">字上げ</td>
+            <td class="xfq-transliteration">jiage<br/>じあげ</td>
+            <td class="xfq-def">
+              <p its-locale-filter-list="en" lang="en">To reserve a certain amount of space before the default position of a line end. (JIS Z 8125)</p>
+              <p its-locale-filter-list="ja" lang="ja">行末の位置を行頭方向に移すこと．（JIS Z 8125）</p>
+            </td>
+          </tr>
+          <tr id="term.line-feed">
+            <td class="xfq-term">line feed</td>
+            <td class="xfq-ja">行送り</td>
+            <td class="xfq-transliteration">gyō okuri<br/>ぎょうおくり</td>
+            <td class="xfq-def">
+              <p its-locale-filter-list="en" lang="en">The distance between two adjacent lines measured by their reference points. (JIS Z 8125)</p>
+              <p its-locale-filter-list="ja" lang="ja">隣接する行同士の基準点から基準点までの距離．（JIS Z 8125）</p>
+            </td>
+          </tr>
+          <tr id="term.line-gap">
+            <td class="xfq-term">line gap</td>
+            <td class="xfq-ja">行間</td>
+            <td class="xfq-transliteration">gyōkan<br/>ぎょうかん</td>
+            <td class="xfq-def">
+              <p its-locale-filter-list="en" lang="en">The smallest amount of space between adjacent lines.</p>
+              <p its-locale-filter-list="ja" lang="ja">隣接する行の文字の外枠間の距離．</p>
+            </td>
+          </tr>
+          <tr id="term.line-head">
+            <td class="xfq-term">line head</td>
+            <td class="xfq-ja">行頭</td>
+            <td class="xfq-transliteration">gyōtō<br/>ぎょうとう</td>
+            <td class="xfq-def">
+              <p its-locale-filter-list="en" lang="en">The  position at which a line starts. (JIS Z 8125)</p>
+              <p its-locale-filter-list="ja" lang="ja">1つの行の始まる位置．（JIS Z 8125）</p>
+            </td>
+          </tr>
+          <tr id="term.line-head-alignment">
+            <td class="xfq-term">line head alignment</td>
+            <td class="xfq-ja">行頭そろえ</td>
+            <td class="xfq-transliteration">gyōtō soroe<br/>ぎょうとうそろえ</td>
+            <td class="xfq-def">
+              <p its-locale-filter-list="en" lang="en">To align a run of text to the line head. (JIS Z 8125)</p>
+              <p its-locale-filter-list="ja" lang="ja">文字列の最初の文字を行頭の位置に合わせること．（JIS Z 8125）</p>
+            </td>
+          </tr>
+          <tr id="term.line-head-indent">
+            <td class="xfq-term">line head indent</td>
+            <td class="xfq-ja">字下げ</td>
+            <td class="xfq-transliteration">jisage<br/>じさげ</td>
+            <td class="xfq-def">
+              <p its-locale-filter-list="en" lang="en">To reserve a certain amount of space after the default position of a line head. (JIS Z 8125)</p>
+              <p its-locale-filter-list="ja" lang="ja">行頭の位置を行末方向に移すこと．（JIS Z 8125）</p>
+            </td>
+          </tr>
+          <tr id="term.line-length">
+            <td class="xfq-term">line length</td>
+            <td class="xfq-ja">行長</td>
+            <td class="xfq-transliteration">gyōchō<br/>ぎょうちょう</td>
+            <td class="xfq-def">
+              <p its-locale-filter-list="en" lang="en">Length of a line with a pre-defined number of characters. When the line is indented at the line head or the line end, it is length of the line from the specified amount of line head indent to the specified amount of line end indent.</p>
+              <p its-locale-filter-list="ja" lang="ja">基本版面で設定した行の行頭から行末までの長さ．字下げ又は字上げした場合は，指定された行頭から行末までの長さ．</p>
+            </td>
+          </tr>
+          <tr id="term.line-end-prohibition-rule">
+            <td class="xfq-term">line-end prohibition rule</td>
+            <td class="xfq-ja">行末禁則</td>
+            <td class="xfq-transliteration">gyōmatsu kinsoku<br/>ぎょうまつきんそく</td>
+            <td class="xfq-def">
+              <p its-locale-filter-list="en" lang="en">A line breaking rule that prohibits specific characters at a line end. (JIS Z 8125)</p>
+              <p its-locale-filter-list="ja" lang="ja">行末に特定の文字を置くことを禁止する規則．（JIS Z 8125）</p>
+            </td>
+          </tr>
+          <tr id="term.line-start-prohibition-rule">
+            <td class="xfq-term">line-start prohibition rule</td>
+            <td class="xfq-ja">行頭禁則</td>
+            <td class="xfq-transliteration">gyōtō kinsoku<br/>ぎょうとうきんそく</td>
+            <td class="xfq-def">
+              <p its-locale-filter-list="en" lang="en">A line breaking rule that prohibits specific characters at a line head. (JIS Z 8125)</p>
+              <p its-locale-filter-list="ja" lang="ja">行頭に特定の文字を置くことを禁止する規則．（JIS Z 8125）</p>
+            </td>
+          </tr>
+          <tr id="term.main-text">
+            <td class="xfq-term">main text</td>
+            <td class="xfq-ja">本文</td>
+            <td class="xfq-transliteration">honbun<br/>ほんぶん</td>
+            <td class="xfq-def">
+              <div its-locale-filter-list="en" lang="en">
+                  <div>a) The principal part of  a book, usually preceded by the front matter, followed by the back matter.</div>
+                  <div>b) The principal part of an article excluding figures, tables, heading, notes, leads and so on.</div>
+                  <div>c) The content of a page excluding running heads and page numbers.</div>
+                  <div>d) The net contents of a book excluding covers, end papers, insets and so on.</div>
+                  <div>(JIS Z 8125)</div>
+              </div>
+              <div its-locale-filter-list="ja" lang="ja">
+                  <div>a）<span class="term_listbody">書籍を構成する主要部分．通常，その前に前付，後には後付が付く．</span></div>
+                  <div>b）<span class="term_listbody">図版，表，見出し，注，リードなどを除いた記事の中の主要部分．</span></div>
+                  <div>c）<span class="term_listbody">ページ内の柱及びノンブルを除いた部分．</span></div>
+                  <div>d）<span class="term_listbody">表紙，見返し，投げ込みなどの付属物を除いた本の中身．</span></div>
+                  <div>（JIS Z 8125）</div>
+              </div>
+            </td>
+          </tr>
+          <tr id="term.matrix">
+            <td class="xfq-term">matrix</td>
+            <td class="xfq-ja">母型</td>
+            <td class="xfq-transliteration">bokei<br/>ぼけい</td>
+            <td class="xfq-def">
+              <p its-locale-filter-list="en" lang="en">A metal mold from which movable type is cast.</p>
+              <p its-locale-filter-list="ja" lang="ja">活字を鋳造する際に，字面を形成する型．</p>
+            </td>
+          </tr>
+          <tr id="term.mawarikomi">
+            <td class="xfq-term">mawarikomi</td>
+            <td class="xfq-ja">回り込み</td>
+            <td class="xfq-transliteration">mawarikomi<br/>まわりこみ</td>
+            <td class="xfq-def">
+              <p its-locale-filter-list="en" lang="en">Text setting style to fill the left line direction space, which is happen to appear because of the arragnement of illustrations, tables, etc. (JIS Z 8125)</p>
+              <p its-locale-filter-list="ja" lang="ja">図版，表組などを配置するために確保した領域の字詰め方向の余白に本文を組み込むこと．（JIS Z 8125）</p>
+            </td>
+          </tr>
+          <tr id="term.mincho-typeface">
+            <td class="xfq-term">Mincho typeface</td>
+            <td class="xfq-ja">明朝体</td>
+            <td class="xfq-transliteration">minchōtai<br/>みんちょうたい</td>
+            <td class="xfq-def">
+              <p its-locale-filter-list="en" lang="en">A major style of Japanese font. Horizontal lines are thin and vertical lines are thick. At the start position and the end position, there are triangular figure representing press of brush. Kana are designed to balance the Kanji design. In Japanese text setting, Mincho typeface is most frequently used for main text, especially for long </p>
+              <p its-locale-filter-list="ja" lang="ja">漢字は，横線に比べて縦線が太く，起筆部と終筆部に三角形が付いている．これに調和するように設計された仮名が作られている．日本語の長文の文書では，最も使用頻度が高い．</p>
+              text.
+              Similar to "serif" of Western typography.</td>
+          </tr>
+          <tr id="term.mixed-text-composition">
+            <td class="xfq-term">mixed text composition</td>
+            <td class="xfq-ja">混植</td>
+            <td class="xfq-transliteration">konshoku<br/>こんしょく</td>
+            <td class="xfq-def">
+                <div its-locale-filter-list="en" lang="en">
+                    <div>a) To interleave Japanese text with Western text in a line (Japanese and Western mixed text composition).</div>
+                    <div> b) To compose text with different sizes of characters (mixed size composition).</div>
+                    <div> c) To compose text with different typefaces (mixed typeface composition).</div>
+                    <div>(JIS Z 8125)</div>
+                </div>
+                <div its-locale-filter-list="ja" lang="ja">
+                  <div>a）<span class="term_listbody">和文と欧文とを併用して組版すること（和欧文混植）．</span></div>
+                  <div>b）<span class="term_listbody">異なる大きさの文字を併用して組版すること（異サイズ混植）．</span></div>
+                  <div>c）<span class="term_listbody">異なる書体を使用して組版すること（異書体混植）．</span></div>
+                  <div>（JIS Z 8125）</div>
+              </div>
+            </td>
+          </tr>
+          <tr id="term.mono-ruby">
+            <td class="xfq-term">mono-ruby</td>
+            <td class="xfq-ja">モノルビ</td>
+            <td class="xfq-transliteration">mono rubi<br/>ものるび</td>
+            <td class="xfq-def">
+              <p its-locale-filter-list="en" lang="en">A method of ruby distribution where a run of ruby text is attached to each base character. (JIS Z 8125)</p>
+              <p its-locale-filter-list="ja" lang="ja">親文字の1字ごとに対応してルビを付けて配置する方法．（JIS Z 8125）</p>
+            </td>
+          </tr>
+          <tr id="term.multi-column-format">
+            <td class="xfq-term">multi-column format</td>
+            <td class="xfq-ja">段組</td>
+            <td class="xfq-transliteration">dangumi<br/>だんぐみ</td>
+            <td class="xfq-def">
+              <p its-locale-filter-list="en" lang="en">A format of text on a page where  text is divided into two or more sections (columns) in the inline direction and each column is separated by a certain amount of space (column space). (JIS Z 8125)</p>
+              <p its-locale-filter-list="ja" lang="ja">連続する1系列の文章を1ページの中で，字詰め方向において，2つ以上の部分（段）に分割し，各部分の間には空白（段間）を設けて文字を配置する方法．（JIS Z 8125）</p>
+            </td>
+          </tr>
+          <tr id="term.multivolume-work">
+            <td class="xfq-term">multivolume work</td>
+            <td class="xfq-ja">多巻物</td>
+            <td class="xfq-transliteration">takanmono<br/>たかんもの</td>
+            <td class="xfq-def">
+              <p its-locale-filter-list="en" lang="en">A set of work published in two or more volumes, as in the complete work or the first/last half volumes.</p>
+              <p its-locale-filter-list="ja" lang="ja">全集，上下巻など，1部の本で2冊以上の図書で構成されているもの．</p>
+            </td>
+          </tr>
+          <tr id="term.naka-tobira">
+            <td class="xfq-term">naka-tobira</td>
+            <td class="xfq-ja">中扉</td>
+            <td class="xfq-transliteration">naka tobira<br/>なかとびら</td>
+            <td class="xfq-def">
+              <p its-locale-filter-list="en" lang="en">A recto or a page inserted to divide two different parts in a book. It often has a title or other text to describe the new part. (JIS Z 8125)</p>
+              <p its-locale-filter-list="ja" lang="ja">書籍の内容が大きく区分される場合に，その内容の区切りをはっきりさせるために本文中に挿入する，標題などを掲げた丁又はページ．（JIS Z 8125）</p>
+            </td>
+          </tr>
+          <tr id="term.nakatsuki">
+            <td class="xfq-term">nakatsuki (nakatsuki-ruby)</td>
+            <td class="xfq-ja">中付き（中付きルビ）</td>
+            <td class="xfq-transliteration">nakatsuki (nakatsuki rubi)<br/>なかつき</td>
+            <td class="xfq-def">
+              <p its-locale-filter-list="en" lang="en">A method of ruby character distribution where each ruby character is aligned to the vertical center of the corresponding base character in vertical writing mode, or to the horizontal center of the base character in horizontal writing mode. (JIS Z 8125)</p>
+              <p its-locale-filter-list="ja" lang="ja">縦組の場合は親文字の天地中央に，横組の場合は親文字の左右中央にルビを付けて配置する方法．（JIS Z 8125）</p>
+            </td>
+          </tr>
+          <tr id="term.new-column">
+            <td class="xfq-term">new column</td>
+            <td class="xfq-ja">改段</td>
+            <td class="xfq-transliteration">kaidan<br/>かいだん</td>
+            <td class="xfq-def">
+              <p its-locale-filter-list="en" lang="en">In multi-column setting, to change to new column before the end of current column.</p>
+              <p its-locale-filter-list="ja" lang="ja">段組で段の途中にもかかわらず，次の見出しなどを新しい段の始めから配置すること．</p>
+            </td>
+          </tr>
+          <tr id="term.new-recto">
+            <td class="xfq-term">new recto</td>
+            <td class="xfq-ja">改丁</td>
+            <td class="xfq-transliteration">kaichō<br/>かいちょう</td>
+            <td class="xfq-def">
+              <p its-locale-filter-list="en" lang="en">To start a new heading or something on a odd page. (JIS Z 8125)</p>
+              <p its-locale-filter-list="ja" lang="ja">奇数ページより新規に見出しなどを始めること．（JIS Z 8125）</p>
+            </td>
+          </tr>
+          <tr id="term.note">
+            <td class="xfq-term">note</td>
+            <td class="xfq-ja">注</td>
+            <td class="xfq-transliteration">chū<br/>ちゅう</td>
+            <td class="xfq-def">
+              <p its-locale-filter-list="en" lang="en">Explanatory information added to terms, figures or tables. (JIS Z 8125)</p>
+              <p its-locale-filter-list="ja" lang="ja">語句，図版，表などに加える補助的な説明・解釈．（JIS Z 8125）</p>
+            </td>
+          </tr>
+          <tr id="term.number-of-characters-per-line">
+            <td class="xfq-term">number of characters per line</td>
+            <td class="xfq-ja">字詰め</td>
+            <td class="xfq-transliteration">jizume<br/>じづめ</td>
+            <td class="xfq-def">
+              <p its-locale-filter-list="en" lang="en">Number of characters in a line to specify the length of lines. (JIS Z 8125)</p>
+              <p its-locale-filter-list="ja" lang="ja">図版，表組などを配置するために確保した領域の字詰め方向の余白に本文を組み込むこと．（JIS Z 8125）</p>
+            </td>
+          </tr>
+          <tr id="term.number-of-columns">
+            <td class="xfq-term">number of columns</td>
+            <td class="xfq-ja">段数</td>
+            <td class="xfq-transliteration">dansū<br/>だんすう</td>
+            <td class="xfq-def">
+              <p its-locale-filter-list="en" lang="en">Number of columns on a page. (JIS Z 8125)</p>
+              <p its-locale-filter-list="ja" lang="ja">1ページ内に配置される段の数．（JIS Z 8125）</p>
+            </td>
+          </tr>
+          <tr id="term.omote-kei">
+            <td class="xfq-term">omote-kei</td>
+            <td class="xfq-ja">表罫</td>
+            <td class="xfq-transliteration">omotekei<br/>おもてけい</td>
+            <td class="xfq-def">
+              <p its-locale-filter-list="en" lang="en">Thin width line. Usually about 0.12mm. (JIS Z 8125)</p>
+              <p its-locale-filter-list="ja" lang="ja">0.1mm程度の太さの実線．（JIS Z 8125）</p>
+            </td>
+          </tr>
+          <tr id="term.one-em-space">
+            <td class="xfq-term">one em space</td>
+            <td class="xfq-ja">全角アキ</td>
+            <td class="xfq-transliteration">zenkaku aki<br/>ぜんかくあき</td>
+            <td class="xfq-def">
+              <p its-locale-filter-list="en" lang="en">Amount of space that is full-width size.</p>
+              <p its-locale-filter-list="ja" lang="ja">全角の空き量．</p>
+            </td>
+          </tr>
+          <tr id="term.one-third-em">
+            <td class="xfq-term">one third em</td>
+            <td class="xfq-ja">三分</td>
+            <td class="xfq-transliteration">sanbu<br/>さんぶ</td>
+            <td class="xfq-def">
+              <p its-locale-filter-list="en" lang="en">One third of the full-width size. (JIS Z 8125)</p>
+              <p its-locale-filter-list="ja" lang="ja">全角の3分の1の長さ．（JIS Z 8125）</p>
+            </td>
+          </tr>
+          <tr id="term.one-third-em-space">
+            <td class="xfq-term">one third em space</td>
+            <td class="xfq-ja">三分アキ</td>
+            <td class="xfq-transliteration">sanbu aki<br/>さんぶあき</td>
+            <td class="xfq-def">
+              <p its-locale-filter-list="en" lang="en">Amount of space that is one third size of em space.</p>
+              <p its-locale-filter-list="ja" lang="ja">三分の空き量．</p>
+            </td>
+          </tr>
+          <tr id="term.one-third-ruby">
+            <td class="xfq-term">one-third-ruby</td>
+            <td class="xfq-ja">三分ルビ</td>
+            <td class="xfq-transliteration">sanbu rubi<br/>さんぶるび</td>
+            <td class="xfq-def">
+              <p its-locale-filter-list="en" lang="en">Ruby characters, narrow enough so that three can fit within the width of a full-width base character.</p>
+              <p its-locale-filter-list="ja" lang="ja">全角の字幅の親文字1字に対し，3文字のルビを親文字からはみ出させないように付けるためのルビ．</p>
+            </td>
+          </tr>
+          <tr id="term.original-pattern">
+            <td class="xfq-term">original pattern</td>
+            <td class="xfq-ja">原図</td>
+            <td class="xfq-transliteration">genzu<br/>げんず</td>
+            <td class="xfq-def">
+              <p its-locale-filter-list="en" lang="en">An original drawn pattern of a character image to be used for a printing type or a digitized glyph.</p>
+              <p its-locale-filter-list="ja" lang="ja">印刷用の文字の元となる描かれた文字．</p>
+            </td>
+          </tr>
+          <tr id="term.ornament-characters">
+            <td class="xfq-term">ornament characters</td>
+            <td class="xfq-ja">添え字</td>
+            <td class="xfq-transliteration">soeji<br/>そえじ</td>
+            <td class="xfq-def">
+              <p its-locale-filter-list="en" lang="en">A superscript or subscript attached to a base character. (JIS Z 8125)</p>
+              <p its-locale-filter-list="ja" lang="ja">文字のそばに付ける上付き文字又は下付き文字．（JIS Z 8125）</p>
+            </td>
+          </tr>
+          <tr id="term.page">
+            <td class="xfq-term">page</td>
+            <td class="xfq-ja">ページ</td>
+            <td class="xfq-transliteration">pēji<br/>ぺーじ</td>
+            <td class="xfq-def">
+              <p its-locale-filter-list="en" lang="en">A side of a sheet of paper in a written work such as a book. (JIS Z 8125)</p>
+              <p its-locale-filter-list="ja" lang="ja">本などを構成する1枚の紙の片面．（JIS Z 8125）</p>
+            </td>
+          </tr>
+          <tr id="term.page-break">
+            <td class="xfq-term">page break</td>
+            <td class="xfq-ja">改ページ</td>
+            <td class="xfq-transliteration">kai pēji<br/>かいぺーじ</td>
+            <td class="xfq-def">
+              <p its-locale-filter-list="en" lang="en">To end a page even if it is not full and to start a new page with the next paragraph, a new heading and so on. (JIS Z 8125)</p>
+              <p its-locale-filter-list="ja" lang="ja">奇数ページ・偶数ページに関わらず，ページの途中であっても次の文章・見出しなどを次のページから新しく始めること．（JIS Z 8125）</p>
+            </td>
+          </tr>
+          <tr id="term.page-format">
+            <td class="xfq-term">page format</td>
+            <td class="xfq-ja">組体裁</td>
+            <td class="xfq-transliteration">kumi teisai<br/>くみていさい</td>
+            <td class="xfq-def">
+              <p its-locale-filter-list="en" lang="en">The layout and presentation of a page with text, graphics and other elements for a publication such as a book.</p>
+              <p its-locale-filter-list="ja" lang="ja">本などの仕上りサイズ及びそこに配置する文字その他の表示体裁．</p>
+            </td>
+          </tr>
+          <tr id="term.page-number">
+            <td class="xfq-term">page number</td>
+            <td class="xfq-ja">ノンブル</td>
+            <td class="xfq-transliteration">nonburu<br/>のんぶる</td>
+            <td class="xfq-def">
+              <p its-locale-filter-list="en" lang="en">A sequential number to indicate the order of pages in a publication. (JIS Z 8125)</p>
+              <p its-locale-filter-list="ja" lang="ja">印刷物の各ページの順序を示すために付けてある番号．（JIS Z 8125）</p>
+            </td>
+          </tr>
+          <tr id="term.para-ruby">
+            <td class="xfq-term">para-ruby</td>
+            <td class="xfq-ja">パラルビ</td>
+            <td class="xfq-transliteration">para rubi<br/>ぱらるび</td>
+            <td class="xfq-def">
+              <p its-locale-filter-list="en" lang="en">A method of ruby annotation where ruby text is only attached to selected Kanji characters in the text. (JIS Z 8125)</p>
+              <p its-locale-filter-list="ja" lang="ja">文中の一部の漢字だけにルビを付けること．（JIS Z 8125）</p>
+            </td>
+          </tr>
+          <tr id="term.paragraph">
+            <td class="xfq-term">paragraph</td>
+            <td class="xfq-ja">段落</td>
+            <td class="xfq-transliteration">danraku<br/>だんらく</td>
+            <td class="xfq-def">
+              <p its-locale-filter-list="en" lang="en">A group of sentences to be processed for line composition. A paragraph consists of one or more lines. (JIS Z 8125)</p>
+              <p its-locale-filter-list="ja" lang="ja">行組版処理の処理単位となる1つ以上の文の集まり．段落は，1行又は連続した複数の行からなる．（JIS Z 8125）</p>
+            </td>
+          </tr>
+          <tr id="term.paragraph-break">
+            <td class="xfq-term">paragraph break</td>
+            <td class="xfq-ja">改行</td>
+            <td class="xfq-transliteration">kaigyō<br/>かいぎょう</td>
+            <td class="xfq-def">
+              <p its-locale-filter-list="en" lang="en">To start a new line to indicate a new paragraph.</p>
+              <p its-locale-filter-list="ja" lang="ja">段落の区切りなどを示すために行を改めること．</p>
+            </td>
+          </tr>
+          <tr id="term.paragraph-format">
+            <td class="xfq-term">paragraph format</td>
+            <td class="xfq-ja">段落整形</td>
+            <td class="xfq-transliteration">danraku seikei<br/>だんらくせいけい</td>
+            <td class="xfq-def">
+              <p its-locale-filter-list="en" lang="en">A format of a paragraph, as in line head indent or line end indent.</p>
+              <p its-locale-filter-list="ja" lang="ja">字下げ，字上げ，インデントなどの段落の書式．</p>
+            </td>
+          </tr>
+          <tr id="term.parallel-note">
+            <td class="xfq-term">parallel-note</td>
+            <td class="xfq-ja">並列注</td>
+            <td class="xfq-transliteration">heiretsuchū<br/>へいれつちゅう</td>
+            <td class="xfq-def">
+              <p its-locale-filter-list="en" lang="en">Areas of notes are kept when the kihon-hanmen is designed. Related notes are set in these areas, with page unit or spread unit. Parallel-note is the general name for head note (in vertical writing mode), foot note (in vertical writing mode) and side note (in horizontal writing mode).</p>
+              <p its-locale-filter-list="ja" lang="ja">基本版面の設計段階であらかじめ注のための領域を確保し，その領域にページ又は見開きを単位として，その範囲にある項目に関連した注を掲げる頭注（縦組），脚注（縦組）及び傍注（横組）の総称．</p>
+            </td>
+          </tr>
+          <tr id="term.point">
+            <td class="xfq-term">point</td>
+            <td class="xfq-ja">ポイント</td>
+            <td class="xfq-transliteration">pointo<br/>ぽいんと</td>
+            <td class="xfq-def">
+              <p its-locale-filter-list="en" lang="en">A measurement unit of character size. 1 point is equal to 0.3514mm (see JIS Z 8305). There is another unit to measure character sizes called Q, where 1Q is equivalent to 0.25mm.</p>
+              <p its-locale-filter-list="ja" lang="ja">文字サイズの単位．1ポイントは0.3514mmに等しい（JIS Z 8305）．なお，ポイント以外に，文字サイズの単位に使用されている1Qは，0.25mmである．</p>
+            </td>
+          </tr>
+          <tr id="term.printing-types">
+            <td class="xfq-term">printing types</td>
+            <td class="xfq-ja">活字</td>
+            <td class="xfq-transliteration">katsuji<br/>かつじ</td>
+            <td class="xfq-def">
+              <p its-locale-filter-list="en" lang="en">Movable type used for letterpress printing.</p>
+              <p its-locale-filter-list="ja" lang="ja">文字組版に使用するもので，文字・数字・記号類などの字面を逆向きで凸状に，鉛合金などで鋳造した角柱．</p>
+            </td>
+          </tr>
+          <tr id="term.proportional">
+            <td class="xfq-term">proportional</td>
+            <td class="xfq-ja">プロポーショナル</td>
+            <td class="xfq-transliteration">puropōshonaru<br/>ぷろぽーしょなる</td>
+            <td class="xfq-def">
+              <p its-locale-filter-list="en" lang="en">A characteristic of a font where  character advance is different per glyph. (JIS Z 8125)</p>
+              <p its-locale-filter-list="ja" lang="ja">1つのフォント中で文字の字幅が一定でなく，文字ごとに独立した字幅の値を持っていること．（JIS Z 8125）</p>
+            </td>
+          </tr>
+          <tr id="term.punctuation-marks">
+            <td class="xfq-term">punctuation marks</td>
+            <td class="xfq-ja">約物</td>
+            <td class="xfq-transliteration">yakumono<br/>やくもの</td>
+            <td class="xfq-def">
+              <p its-locale-filter-list="en" lang="en">A general term referring to the symbols used in text composition to help make the meaning of text clearer, as in commas, full stops, question marks, brackets, diereses and so on. (JIS Z 8125)</p>
+              <p its-locale-filter-list="ja" lang="ja">文字組版に使用する記述記号類の総称．備考：句読点・疑問符・括弧・アクセントなど．（JIS Z 8125）</p>
+            </td>
+          </tr>
+          <tr id="term.quarter-em">
+            <td class="xfq-term">quarter em</td>
+            <td class="xfq-ja">四分</td>
+            <td class="xfq-transliteration">shibu<br/>しぶ</td>
+            <td class="xfq-def">
+              <p its-locale-filter-list="en" lang="en">Quarter size of full-width.</p>
+              <p its-locale-filter-list="ja" lang="ja">全角の4分の1の長さ．（JIS Z 8125）</p>
+            </td>
+          </tr>
+          <tr id="term.quarter-em-space">
+            <td class="xfq-term">quarter em space</td>
+            <td class="xfq-ja">四分アキ</td>
+            <td class="xfq-transliteration">shibu aki<br/>しぶあき</td>
+            <td class="xfq-def">
+              <p its-locale-filter-list="en" lang="en">Amount of space that is a quarter of an em space in size.</p>
+              <p its-locale-filter-list="ja" lang="ja">四分の空き量．</p>
+            </td>
+          </tr>
+          <tr id="term.quarter-em-width">
+            <td class="xfq-term">quarter em width</td>
+            <td class="xfq-ja">四分角</td>
+            <td class="xfq-transliteration">shibu kaku<br/>しぶかく</td>
+            <td class="xfq-def">
+              <p its-locale-filter-list="en" lang="en">Character frame which has a character advance  of a quarter em. (JIS X 4051)</p>
+              <p its-locale-filter-list="ja" lang="ja">字幅が，全角の1/4である文字の外枠．（JIS X 4051）</p>
+            </td>
+          </tr>
+          <tr id="term.quotation">
+            <td class="xfq-term">quotation</td>
+            <td class="xfq-ja">引用文</td>
+            <td class="xfq-transliteration">in-yōbun<br/>いんようぶん</td>
+            <td class="xfq-def">
+              <p its-locale-filter-list="en" lang="en">Excerps from other published works. (JIS Z 8125)</p>
+              <p its-locale-filter-list="ja" lang="ja">公表された他の著作物から，その一部を引用して利用するもの．（JIS Z 8125）</p>
+            </td>
+          </tr>
+          <tr id="term.reference-marks">
+            <td class="xfq-term">reference marks</td>
+            <td class="xfq-ja">合印</td>
+            <td class="xfq-transliteration">aijirushi<br/>あいじるし</td>
+            <td class="xfq-def">
+              <p its-locale-filter-list="en" lang="en">A symbol or short run of text attached to a specific part of text, to which notes are provided followed by the corresponding marks.</p>
+              <p its-locale-filter-list="ja" lang="ja">注と本文文字列などの該当項目とを対応させるために該当項目に付ける文字列．</p>
+            </td>
+          </tr>
+          <tr id="term.reverse-pagination">
+            <td class="xfq-term">reverse pagination</td>
+            <td class="xfq-ja">逆ノンブル</td>
+            <td class="xfq-transliteration">gyaku nonburu<br/>ぎゃくのんぶる</td>
+            <td class="xfq-def">
+              <p its-locale-filter-list="en" lang="en">Numbering pages of a book backwards. (JIS Z 8125)</p>
+              <p its-locale-filter-list="ja" lang="ja">巻末の方からページの番号を開始するノンブル．（JIS Z 8125）</p>
+            </td>
+          </tr>
+          <tr id="term.roman-numerals">
+            <td class="xfq-term">Roman numerals</td>
+            <td class="xfq-ja">ローマ数字</td>
+            <td class="xfq-transliteration">rōma sūji<br/>ろーますうじ</td>
+            <td class="xfq-def">
+              <p its-locale-filter-list="en" lang="en">Numerals represented by upper case or lower case of Latin letters. (JIS Z 8125)</p>
+              <p its-locale-filter-list="ja" lang="ja">ラテン文字の大文字又は小文字を用いて表記する数字．（JIS Z 8125）</p>
+            </td>
+          </tr>
+          <tr id="term.ruby">
+            <td class="xfq-term">ruby</td>
+            <td class="xfq-ja">ルビ</td>
+            <td class="xfq-transliteration">rubi<br/>るび</td>
+            <td class="xfq-def">
+              <p its-locale-filter-list="en" lang="en">Supplementary small characters indicating pronunciation, meaning, etc. for the character or the block of characters they annotate. (JIS Z 8125) (Sometimes these annotations are referred to as "furigana".)</p>
+              <p its-locale-filter-list="ja" lang="ja">文字及び語のそばに付けて，その読み，意味などを示す小さな文字．（JIS Z 8125）“振り仮名”ともよばれることがある．</p>
+            </td>
+          </tr>
+          <tr id="term.run-in-heading">
+            <td class="xfq-term">run-in heading</td>
+            <td class="xfq-ja">同行見出し</td>
+            <td class="xfq-transliteration">dōgyōmidashi<br/>どうぎょうみだし</td>
+            <td class="xfq-def">
+              <p its-locale-filter-list="en" lang="en">A kind of heading style to continue main text just after the heading without line break.</p>
+              <p its-locale-filter-list="ja" lang="ja">見出しに続く文章を改行することなく，見出しに続けて文章を配置する形式の見出し．</p>
+            </td>
+          </tr>
+          <tr id="term.running-head">
+            <td class="xfq-term">running head</td>
+            <td class="xfq-ja">柱</td>
+            <td class="xfq-transliteration">hashira<br/>はしら</td>
+            <td class="xfq-def">
+              <p its-locale-filter-list="en" lang="en">A page element which contains information on the title of the book, chapter, section and so on, printed outside the area of the hanmen. (JIS Z 8125)</p>
+              <p its-locale-filter-list="ja" lang="ja">各ページの版面外に記載された書名・章名・節名など．（JIS Z 8125）</p>
+            </td>
+          </tr>
+          <tr id="term.second-level-heading">
+            <td class="xfq-term">second level heading</td>
+            <td class="xfq-ja">中見出し</td>
+            <td class="xfq-transliteration">nakamidashi<br/>なかみだし</td>
+            <td class="xfq-def">
+              <p its-locale-filter-list="en" lang="en">Second level and middle size heading between first level heading and third level heading. (JIS Z 8125)</p>
+              <p its-locale-filter-list="ja" lang="ja">大見出しと小見出しとの中間の区分に付ける標題．（JIS Z 8125）</p>
+            </td>
+          </tr>
+          <tr id="term.sidenote">
+            <td class="xfq-term">sidenote</td>
+            <td class="xfq-ja">傍注</td>
+            <td class="xfq-transliteration">bōchū<br/>ぼうちゅう</td>
+            <td class="xfq-def">
+              <p its-locale-filter-list="en" lang="en">A kind of notes, in vertical writing mode with spread unit, and related notes are set from the left end of left page with smaller size font than the main text. A kind of notes, in horizontal writing mode, the realm is kept beforhand in right side or fore-edge side of kihon-hanmen, and related notes are set in the realm with smaller size font than main text.</p>
+              <p its-locale-filter-list="ja" lang="ja">縦組において，見開きを単位として，そこに関連する注を左ページ（奇数ページ）の左端に本文よりも小さな文字サイズにして掲げる注．横組において，基本版面内の小口側又は右側に注を配置するための領域をあらかじめ設定し，その領域に本文よりも小さな文字サイズにして掲げる注．</p>
+            </td>
+          </tr>
+          <tr id="term.single-line-alignment-method">
+            <td class="xfq-term">single line alignment method</td>
+            <td class="xfq-ja">そろえ</td>
+            <td class="xfq-transliteration">soroe<br/>かたばしらほうしき</td>
+            <td class="xfq-def">
+              <p its-locale-filter-list="en" lang="en">To align a run of text that is shorter than a given line length to designated positions.</p>
+              <p its-locale-filter-list="ja" lang="ja">1行の文字列について，指定した位置に文字の配置位置を合わせること．</p>
+            </td>
+          </tr>
+          <tr id="term.single-running-head-method">
+            <td class="xfq-term">single running head method</td>
+            <td class="xfq-ja">片柱方式</td>
+            <td class="xfq-transliteration">katabashira hōshiki<br/>かたばしらほうしき</td>
+            <td class="xfq-def">
+              <p its-locale-filter-list="en" lang="en">A method that puts running heads only on odd pages. (JIS Z 8125)</p>
+              <p its-locale-filter-list="ja" lang="ja">柱を奇数ページだけに掲げること．（JIS Z 8125）</p>
+            </td>
+          </tr>
+          <tr id="term.small-kana">
+            <td class="xfq-term">small kana</td>
+            <td class="xfq-ja">小書きの仮名</td>
+            <td class="xfq-transliteration">kogaki no kana<br/>こがきのかな</td>
+            <td class="xfq-def">
+              <p its-locale-filter-list="en" lang="en">Kana with smaller letter faces to be used mainly for representing contracted sounds or prolonged vowels. (JIS Z 8125)</p>
+              <p its-locale-filter-list="ja" lang="ja">拗音，促音，外来語などを書き表す場合に用いる，字面を小さくした仮名．捨て仮名，半音ともいう．（JIS Z 8125）</p>
+            </td>
+          </tr>
+          <tr id="term.solid-setting">
+            <td class="xfq-term">solid setting</td>
+            <td class="xfq-ja">ベタ組</td>
+            <td class="xfq-transliteration">beta gumi<br/>べたぐみ</td>
+            <td class="xfq-def">
+              <p its-locale-filter-list="en" lang="en">To arrange characters with no inter-character space between adjacent character frames.</p>
+              <p its-locale-filter-list="ja" lang="ja">字間を空けずに文字の外枠を接して文字を配置すること．</p>
+            </td>
+          </tr>
+          <tr id="term.space">
+            <td class="xfq-term">space</td>
+            <td class="xfq-ja">アキ</td>
+            <td class="xfq-transliteration">aki<br/>あき</td>
+            <td class="xfq-def">
+              <p its-locale-filter-list="en" lang="en">Amount of space between adjacent characters or lines. It also refers to the blank area between the edges of a hanmen or an illustration and text or other hanmen elements.</p>
+              <p its-locale-filter-list="ja" lang="ja">隣接する文字又は隣接する行の間隔．また，版面，図版などの端から文字列などの端までの間隔．</p>
+            </td>
+          </tr>
+          <tr id="term.spread">
+            <td class="xfq-term">spread</td>
+            <td class="xfq-ja">見開き</td>
+            <td class="xfq-transliteration">mihiraki<br/>みひらき</td>
+            <td class="xfq-def">
+              <p its-locale-filter-list="en" lang="en">Any two facing pages when opening a book and the like. (JIS Z 8125)</p>
+              <p its-locale-filter-list="ja" lang="ja">本などを開いたときの両方のページ．（JIS Z 8125）</p>
+            </td>
+          </tr>
+          <tr id="term.subscript">
+            <td class="xfq-term">subscript (inferior)</td>
+            <td class="xfq-ja">下付き</td>
+            <td class="xfq-transliteration">shitatsuki<br/>したつき</td>
+            <td class="xfq-def">
+              <p its-locale-filter-list="en" lang="en">Smaller face of characters, attached to the lower right or the lower left of a normal size character. (JIS Z 8125)</p>
+              <p its-locale-filter-list="ja" lang="ja">小さい字面の文字で，通常の大きさの文字の右下又は左下に付けて配置する文字．（JIS Z 8125）</p>
+            </td>
+          </tr>
+          <tr id="term.subtitle">
+            <td class="xfq-term">subtitle</td>
+            <td class="xfq-ja">副題</td>
+            <td class="xfq-transliteration">fukudai<br/>ふくだい</td>
+            <td class="xfq-def">
+              <p its-locale-filter-list="en" lang="en">Secondary title for headings, subtile. (JIS X 4051)</p>
+              <p its-locale-filter-list="ja" lang="ja">見出しに付ける副次的な標題．サブタイトルともいう．（JIS X 4051）</p>
+            </td>
+          </tr>
+          <tr id="term.superscript">
+            <td class="xfq-term">superscript (superior)</td>
+            <td class="xfq-ja">上付き</td>
+            <td class="xfq-transliteration">uwatsuki<br/>うわつき</td>
+            <td class="xfq-def">
+              <p its-locale-filter-list="en" lang="en">Smaller face of characters, attached to the upper right or the upper left of a normal size character. (JIS Z 8125)</p>
+              <p its-locale-filter-list="ja" lang="ja">小さい字面の文字で，通常の大きさの文字の右肩又は左肩に付けて配置する文字．（JIS Z 8125）</p>
+            </td>
+          </tr>
+          <tr id="term.tab-setting">
+            <td class="xfq-term">tab setting</td>
+            <td class="xfq-ja">タブ処理</td>
+            <td class="xfq-transliteration">tabu shori<br/>たぶしょり</td>
+            <td class="xfq-def">
+              <p its-locale-filter-list="en" lang="en">A method of line composition to align one or more runs of text to  designated positions on a line.</p>
+              <p its-locale-filter-list="ja" lang="ja">行において，1つ又は複数の文字列を指定位置に合わせて配置する処理．</p>
+            </td>
+          </tr>
+          <tr id="term.table">
+            <td class="xfq-term">table</td>
+            <td class="xfq-ja">表</td>
+            <td class="xfq-transliteration">hyō<br/>ひょう</td>
+            <td class="xfq-def">
+              <p its-locale-filter-list="en" lang="en">Formatted data consisting of characters or numbers, arranged in cells and sometimes divided by lines, in order to present the data in a way that is easier to understand. (JIS Z 8125)</p>
+              <p its-locale-filter-list="ja" lang="ja">文字又は数字を一覧できるように，罫などで区切ったこま（小間）に配列したもの．（JIS Z 8125）</p>
+            </td>
+          </tr>
+          <tr id="term.table-of-contents">
+            <td class="xfq-term">table of contents</td>
+            <td class="xfq-ja">目次</td>
+            <td class="xfq-transliteration">mokuji<br/>もくじ</td>
+            <td class="xfq-def">
+              <p its-locale-filter-list="en" lang="en">A list of headings of contents of a book in page order or arranged by subjects, with page numbers on which each section begins. (JIS Z 8125)</p>
+              <p its-locale-filter-list="ja" lang="ja">本の内容の見出しを，書かれている順又は分野別に並べて，それぞれの該当ページ番号を示したもの．（JIS Z 8125）</p>
+            </td>
+          </tr>
+          <tr id="term.tate-chu-yoko">
+            <td class="xfq-term">tate-chu-yoko</td>
+            <td class="xfq-ja">縦中横</td>
+            <td class="xfq-transliteration">tate chū yoko<br/>たてちゅうよこ</td>
+            <td class="xfq-def">
+              <p its-locale-filter-list="en" lang="en">To typeset a (small) group of characters horizontally within a vertical line of main text.</p>
+              <p its-locale-filter-list="ja" lang="ja">縦組の行中で，文字を縦向きのまま横組にすること．</p>
+            </td>
+          </tr>
+          <tr id="term.tentsuki">
+            <td class="xfq-term">tentsuki</td>
+            <td class="xfq-ja">天付き</td>
+            <td class="xfq-transliteration">tentsuki<br/>てんつき</td>
+            <td class="xfq-def">
+              <div its-locale-filter-list="en" lang="en">
+                  <div>a) To remove conditional space from opening brackets at a line head to align the line head to the ones of the adjacent lines.</div>
+                  <div> b) Not to add the default line head indent for the first line of a paragraph so as to align all line heads.</div>
+                  <div>(JIS Z 8125)</div>
+              </div>
+              <div its-locale-filter-list="ja" lang="ja">
+                  <div>a）<span class="term_listbody">行頭に位置した括弧類に二分の字幅のものなどを使用して，隣接する行の行頭とそろえること．</span></div>
+                  <div>b）<span class="term_listbody">段落最初の行において行頭の字下げを行わないで，隣接する行の行頭とそろえること．</span></div>
+                  <div>（JIS Z 8125）</div>
+              </div>
+            </td>
+          </tr>
+          <tr id="term.text-direction">
+            <td class="xfq-term">text direction</td>
+            <td class="xfq-ja">組方向</td>
+            <td class="xfq-transliteration">kumi hōkō<br/>くみほうこう</td>
+            <td class="xfq-def">
+              <p its-locale-filter-list="en" lang="en">Horizontal setting or vertical setting. (JIS Z 8125)</p>
+              <p its-locale-filter-list="ja" lang="ja">横組又は縦組．（JIS Z 8125）</p>
+            </td>
+          </tr>
+          <tr id="term.third-level-heading">
+            <td class="xfq-term">third level heading</td>
+            <td class="xfq-ja">小見出し</td>
+            <td class="xfq-transliteration">komidashi<br/>こみだし</td>
+            <td class="xfq-def">
+              <p its-locale-filter-list="en" lang="en">Headings for smallest or minimum unit of main text in books.</p>
+              <p its-locale-filter-list="ja" lang="ja">書籍などで，区分の最小のまとまりに付ける標題．</p>
+            </td>
+          </tr>
+          <tr id="term.top-level-heading">
+            <td class="xfq-term">top level heading</td>
+            <td class="xfq-ja">大見出し</td>
+            <td class="xfq-transliteration">ōmidashi<br/>おおみだし</td>
+            <td class="xfq-def">
+              <p its-locale-filter-list="en" lang="en">Headings for largest or muximum unit of main text in books.</p>
+              <p its-locale-filter-list="ja" lang="ja">書籍などで，区分の最大のまとまりに付ける標題．</p>
+            </td>
+          </tr>
+          <tr id="term.touyou-kanji-table">
+            <td class="xfq-term">Touyou Kanji Table</td>
+            <td class="xfq-ja">当用漢字表</td>
+            <td class="xfq-transliteration">tōyō kanji hyō<br/>とうようかんじひょう</td>
+            <td class="xfq-def">
+              <p its-locale-filter-list="en" lang="en">The official list of Kanji characters established in 1946, which was designed to restrict the Kanji characters for general use in society to only those 1850 specified in the list. The list together with other related tables was superseded by the Jouyou Kanji Table.</p>
+              <p its-locale-filter-list="ja" lang="ja">1946年に制定された一般社会で使用する漢字の範囲を示す表．1850字の漢字が示されている．この表は，当用漢字音訓表，当用漢字字体表とともに常用漢字表に改められた．</p>
+            </td>
+          </tr>
+          <tr id="term.trim-size">
+            <td class="xfq-term">trim size</td>
+            <td class="xfq-ja">仕上りサイズ</td>
+            <td class="xfq-transliteration">shiagari saizu<br/>しあがりさいず</td>
+            <td class="xfq-def">
+              <p its-locale-filter-list="en" lang="en">Dimensions of a full page in a publication, including margins. (JIS Z 8125)</p>
+              <p its-locale-filter-list="ja" lang="ja">仕上げ裁ちした印刷物の寸法．（JIS Z 8125）</p>
+            </td>
+          </tr>
+          <tr id="term.tsumegumi">
+            <td class="xfq-term">tsumegumi</td>
+            <td class="xfq-ja">詰め組</td>
+            <td class="xfq-transliteration">tsumegumi<br/>つめぐみ</td>
+            <td class="xfq-def">
+              <p its-locale-filter-list="en" lang="en">Adjustment of inter-character space by making the distance between the letter face of adjacent characters shorter than that produced by solid setting. (JIS Z 8125) </p>
+              <p its-locale-filter-list="ja" lang="ja">ベタ組より字送りを詰めて文字を配置する方法（JIS Z 8125）．なお，字送りとは，同一行の隣接する文字同士の基準点から基準点までの距離（JIS Z 8125）．</p>
+            </td>
+          </tr>
+          <tr id="term.type-picking">
+            <td class="xfq-term">type-picking</td>
+            <td class="xfq-ja">文選</td>
+            <td class="xfq-transliteration">bunsen<br/>ぶんせん</td>
+            <td class="xfq-def">
+              <p its-locale-filter-list="en" lang="en">To select metal type for characters needed to print a manuscript. (Metal type is stored in a type case, but because the number of Japanese characters is very large, an extra operation was invented that involves collecting type in a so-called 'bunsen box' before typesetting a manuscript using a composing stick.)</p>
+              <p its-locale-filter-list="ja" lang="ja">原稿で指示された文字について，その活字を拾い集める作業．具体的には活字を配列してある活字ケースから文字を選び，文選箱に収める．</p>
+            </td>
+          </tr>
+          <tr id="term.typeface">
+            <td class="xfq-term">typeface</td>
+            <td class="xfq-ja">書体</td>
+            <td class="xfq-transliteration">shotai<br/>しょたい</td>
+            <td class="xfq-def">
+              <p its-locale-filter-list="en" lang="en">A set of letters or symbols, which are designed to have coherent patterns to be used for printing or rendering to a computer screen. (JIS Z 8125)</p>
+              <p its-locale-filter-list="ja" lang="ja">印字，画面表示などに使用するため，統一的な意図に基づいて作成された一組の文字又は記号の意匠．（JIS Z 8125）</p>
+            </td>
+          </tr>
+          <tr id="term.unbreakable-characters-rule">
+            <td class="xfq-term">unbreakable characters rule</td>
+            <td class="xfq-ja">分割禁止</td>
+            <td class="xfq-transliteration">bunkatsu kinshi<br/>ぶんかつきんし</td>
+            <td class="xfq-def">
+              <p its-locale-filter-list="en" lang="en">A line breaking rule that prohibits breaking a line between consecutive dashes or leaders, or between other specific combinations of characters.</p>
+              <p its-locale-filter-list="ja" lang="ja">ダッシュ，リーダなど連続した同じ文字間，又は特定の文字の組の文字間では分割を禁止する規則．</p>
+            </td>
+          </tr>
+          <tr id="term.underline">
+            <td class="xfq-term">underline</td>
+            <td class="xfq-ja">下線</td>
+            <td class="xfq-transliteration">kasen<br/>かせん</td>
+            <td class="xfq-def">
+              <p its-locale-filter-list="en" lang="en">A line drawn under a character or a run of text in horizontal writing mode. (JIS Z 8125)</p>
+              <p its-locale-filter-list="ja" lang="ja">横組において，文字又は文字列の下に引いた線．（JIS Z 8125）</p>
+            </td>
+          </tr>
+          <tr id="term.ura-kei">
+            <td class="xfq-term">ura-kei</td>
+            <td class="xfq-ja">裏罫</td>
+            <td class="xfq-transliteration">urakei<br/>うらけい</td>
+            <td class="xfq-def">
+              <p its-locale-filter-list="en" lang="en">Thick width line. Usually about 0.4mm. (JIS Z 8125)</p>
+              <p its-locale-filter-list="ja" lang="ja">0.4mm程度の太さの実線．（JIS Z 8125）</p>
+            </td>
+          </tr>
+          <tr id="term.vertical-writing-mode">
+            <td class="xfq-term">vertical writing mode</td>
+            <td class="xfq-ja">縦組</td>
+            <td class="xfq-transliteration">tate gumi<br/>たてぐみ</td>
+            <td class="xfq-def">
+              <p its-locale-filter-list="en" lang="en">The process or the result of arranging characters on a line from top to bottom, of lines on a page from right to left, and/or of columns on a page from top to bottom. (JIS Z 8125)</p>
+              <p its-locale-filter-list="ja" lang="ja">行においては文字を垂直方向に上から下へ，ページにおいて行を右から左へ，段を上から下へ配列すること．また，そのように文字が配置された状態．（JIS Z 8125）</p>
+            </td>
+          </tr>
+          <tr id="term.warichu">
+            <td class="xfq-term">warichu (inline cutting note)</td>
+            <td class="xfq-ja">割注</td>
+            <td class="xfq-transliteration">warichū<br/>わりちゅう</td>
+            <td class="xfq-def">
+              <p its-locale-filter-list="en" lang="en">A note of two or more lines inserted in the text. It includes brackets which surround the note (JIS Z 8125)</p>
+              <p its-locale-filter-list="ja" lang="ja">本文中で，複数行に割書きした注釈．割注には，割書きを囲む括弧類を含む．（JIS Z 8125）</p>
+            </td>
+          </tr>
+          <tr id="term.weight">
+            <td class="xfq-term">weight</td>
+            <td class="xfq-ja">ウェイト</td>
+            <td class="xfq-transliteration">weito<br/>うぇいと</td>
+            <td class="xfq-def">
+              <p its-locale-filter-list="en" lang="en">A measurement of the thickness of fonts. (JIS Z 8125)</p>
+              <p its-locale-filter-list="ja" lang="ja">書体における字形の画線の太さの指標．（JIS Z 8125）</p>
+            </td>
+          </tr>
+          <tr id="term.widow">
+            <td class="xfq-term">widow</td>
+            <td class="xfq-ja">ウィドウ</td>
+            <td class="xfq-transliteration">widō<br/>うぃどう</td>
+            <td class="xfq-def">
+              <p its-locale-filter-list="en" lang="en">The term in Western text layout to describe that the last line of a paragraph with only a few words  appears at the top of a new page or a column. (JIS Z 8125)</p>
+              <p its-locale-filter-list="ja" lang="ja">欧文組版において，2単語程度である段落の最終行が，新しいページ又は段の第1行目にくること．（JIS Z 8125）</p>
+            </td>
+          </tr>
+          <tr id="term.widow-adjustment">
+            <td class="xfq-term">widow adjustment</td>
+            <td class="xfq-ja">段落末尾処理</td>
+            <td class="xfq-transliteration">danraku matsubi shori<br/>だんらくまつびしょり</td>
+            <td class="xfq-def">
+              <p its-locale-filter-list="en" lang="en">A method of line composition to adjust lines  in a paragraph so that the last line consists of more than a given number of characters.</p>
+              <p its-locale-filter-list="ja" lang="ja">段落の最終行に配置する行の字数が所定の字数未満にならないようにする処理．</p>
+            </td>
+          </tr>
+        </tbody>
+      </table>
+  
+  </section>
 
 
 

--- a/index.html
+++ b/index.html
@@ -22742,7 +22742,7 @@
         <tr>
           <th><span its-locale-filter-list="en" lang="en">Terminology</span> <span its-locale-filter-list="ja" lang="ja">用語（英語）</span></th>
           <th><span its-locale-filter-list="en" lang="en">Japanese</span> <span its-locale-filter-list="ja" lang="ja">用語（日本語）</span></th>
-          <th>Transliteration</th>
+          <th><span its-locale-filter-list="en" lang="en">Transliteration</span> <span its-locale-filter-list="ja" lang="ja">よみ</span></th>
           <th><span its-locale-filter-list="en" lang="en">Definition</span> <span its-locale-filter-list="ja" lang="ja">定義</span></th>
         </tr>
       </thead>


### PR DESCRIPTION
Fix #60 using the method in https://github.com/w3c/jlreq/issues/60#issuecomment-503525335

Two things I haven't done yet:

* Translate the word "Transliteration" into Japanese
* Add JavaScript to sort by the first two columns

IMO the second point can be done after the merge.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/jlreq/pull/88.html" title="Last updated on Jul 1, 2019, 6:26 AM UTC (6ae9a5a)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/jlreq/88/1b85b17...6ae9a5a.html" title="Last updated on Jul 1, 2019, 6:26 AM UTC (6ae9a5a)">Diff</a>