### PR TITLE
Minor tweak. Add br between en and ja table headings in glossary

### DIFF
--- a/index.html
+++ b/index.html
@@ -22740,10 +22740,10 @@
   <table class="termlist">
       <thead>
         <tr>
-          <th><span its-locale-filter-list="en" lang="en">Terminology</span> <span its-locale-filter-list="ja" lang="ja">用語（英語）</span></th>
-          <th><span its-locale-filter-list="en" lang="en">Japanese</span> <span its-locale-filter-list="ja" lang="ja">用語（日本語）</span></th>
-          <th><span its-locale-filter-list="en" lang="en">Transliteration</span> <span its-locale-filter-list="ja" lang="ja">よみ</span></th>
-          <th><span its-locale-filter-list="en" lang="en">Definition</span> <span its-locale-filter-list="ja" lang="ja">定義</span></th>
+          <th><span its-locale-filter-list="en" lang="en">Terminology</span><br/><span its-locale-filter-list="ja" lang="ja">用語（英語）</span></th>
+          <th><span its-locale-filter-list="en" lang="en">Japanese</span><br/><span its-locale-filter-list="ja" lang="ja">用語（日本語）</span></th>
+          <th><span its-locale-filter-list="en" lang="en">Transliteration</span><br/><span its-locale-filter-list="ja" lang="ja">よみ</span></th>
+          <th><span its-locale-filter-list="en" lang="en">Definition</span><br/><span its-locale-filter-list="ja" lang="ja">定義</span></th>
         </tr>
       </thead>
       <tbody>


### PR DESCRIPTION



<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/r12a/jlreq/pull/95.html" title="Last updated on Jul 3, 2019, 9:55 AM UTC (03c9ee1)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/jlreq/95/a9d9317...r12a:03c9ee1.html" title="Last updated on Jul 3, 2019, 9:55 AM UTC (03c9ee1)">Diff</a>