### PR TITLE
termlist table: added min-width 4em for Japanese columns; copied style from 2nd ed.

### DIFF
--- a/index.html
+++ b/index.html
@@ -22741,8 +22741,8 @@
       <thead>
         <tr>
           <th><span its-locale-filter-list="en" lang="en">Terminology</span> <span its-locale-filter-list="ja" lang="ja">用語（英語）</span></th>
-          <th class="colminwidth"><span its-locale-filter-list="en" lang="en">Japanese</span> <span its-locale-filter-list="ja" lang="ja">用語（日本語）</span></th>
-          <th class="colminwidth"><span its-locale-filter-list="en" lang="en">Transliteration</span> <span its-locale-filter-list="ja" lang="ja">よみ</span></th>
+          <th><span its-locale-filter-list="en" lang="en">Japanese</span> <span its-locale-filter-list="ja" lang="ja">用語（日本語）</span></th>
+          <th><span its-locale-filter-list="en" lang="en">Transliteration</span> <span its-locale-filter-list="ja" lang="ja">よみ</span></th>
           <th><span its-locale-filter-list="en" lang="en">Definition</span> <span its-locale-filter-list="ja" lang="ja">定義</span></th>
         </tr>
       </thead>

--- a/index.html
+++ b/index.html
@@ -22741,8 +22741,8 @@
       <thead>
         <tr>
           <th><span its-locale-filter-list="en" lang="en">Terminology</span><br/><span its-locale-filter-list="ja" lang="ja">用語（英語）</span></th>
-          <th><span its-locale-filter-list="en" lang="en">Japanese</span><br/><span its-locale-filter-list="ja" lang="ja">用語（日本語）</span></th>
-          <th><span its-locale-filter-list="en" lang="en">Transliteration</span><br/><span its-locale-filter-list="ja" lang="ja">よみ</span></th>
+          <th class="colminwidth"><span its-locale-filter-list="en" lang="en">Japanese</span><br/><span its-locale-filter-list="ja" lang="ja">用語（日本語）</span></th>
+          <th class="colminwidth"><span its-locale-filter-list="en" lang="en">Transliteration</span><br/><span its-locale-filter-list="ja" lang="ja">よみ</span></th>
           <th><span its-locale-filter-list="en" lang="en">Definition</span><br/><span its-locale-filter-list="ja" lang="ja">定義</span></th>
         </tr>
       </thead>

--- a/index.html
+++ b/index.html
@@ -22740,10 +22740,10 @@
   <table class="termlist">
       <thead>
         <tr>
-          <th><span its-locale-filter-list="en" lang="en">Terminology</span><br/><span its-locale-filter-list="ja" lang="ja">用語（英語）</span></th>
-          <th class="colminwidth"><span its-locale-filter-list="en" lang="en">Japanese</span><br/><span its-locale-filter-list="ja" lang="ja">用語（日本語）</span></th>
-          <th class="colminwidth"><span its-locale-filter-list="en" lang="en">Transliteration</span><br/><span its-locale-filter-list="ja" lang="ja">よみ</span></th>
-          <th><span its-locale-filter-list="en" lang="en">Definition</span><br/><span its-locale-filter-list="ja" lang="ja">定義</span></th>
+          <th><span its-locale-filter-list="en" lang="en">Terminology</span> <span its-locale-filter-list="ja" lang="ja">用語（英語）</span></th>
+          <th class="colminwidth"><span its-locale-filter-list="en" lang="en">Japanese</span> <span its-locale-filter-list="ja" lang="ja">用語（日本語）</span></th>
+          <th class="colminwidth"><span its-locale-filter-list="en" lang="en">Transliteration</span> <span its-locale-filter-list="ja" lang="ja">よみ</span></th>
+          <th><span its-locale-filter-list="en" lang="en">Definition</span> <span its-locale-filter-list="ja" lang="ja">定義</span></th>
         </tr>
       </thead>
       <tbody>

--- a/local.css
+++ b/local.css
@@ -167,6 +167,10 @@ ol li li li {
     padding-left: .5em;
 	}
 
+.termlist th span:not(.hidden) {
+	display: inline-block;
+	}
+
 .termlist th {
 	min-width: 4em;
 	}

--- a/local.css
+++ b/local.css
@@ -182,7 +182,7 @@ ol li li li {
 
 .termlist th,
 .termlist td {
-	border: solid 1px #ccc,
+	border: solid 1px #ccc;
 	padding: 0 0.5em;
 	}
 

--- a/local.css
+++ b/local.css
@@ -173,6 +173,7 @@ ol li li li {
 
 .termlist th {
 	min-width: 4em;
+    white-space: nowrap;
 	}
 
 .termlist {

--- a/local.css
+++ b/local.css
@@ -167,18 +167,18 @@ ol li li li {
     padding-left: .5em;
 	}
 
-table.termlist th.colminwidth {
+.termlist th {
 	min-width: 4em;
 	}
 
-table.termlist {
+.termlist {
 	border-collapse: collapse;
 	}
 
-table.termlist th,
-table.termlist td {
-	border: solid thin gray,
-	padding: 0.2em;
+.termlist th,
+.termlist td {
+	border: solid 1px #ccc,
+	padding: 0 0.5em;
 	}
 
 

--- a/local.css
+++ b/local.css
@@ -167,13 +167,19 @@ ol li li li {
     padding-left: .5em;
 	}
 
+table.termlist th.colminwidth {
+	min-width: 4em;
+	}
 
+table.termlist {
+	border-collapse: collapse;
+	}
 
-
-
-
-
-
+table.termlist th,
+table.termlist td {
+	border: solid thin gray,
+	padding: 0.2em;
+	}
 
 
 


### PR DESCRIPTION
for issue #6, replace PR #59


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/himorin/jlreq/pull/99.html" title="Last updated on Oct 11, 2019, 2:22 PM UTC (cb32fce)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/jlreq/99/503818a...himorin:cb32fce.html" title="Last updated on Oct 11, 2019, 2:22 PM UTC (cb32fce)">Diff</a>