### PR TITLE
added text to gap-analysis 4.1, on JLReq 3.1.7, 3.1.8

### DIFF
--- a/gap-analysis/index.html
+++ b/gap-analysis/index.html
@@ -397,7 +397,11 @@
     <p class="status_prompt">Does the browser capture the rules about the way text in your script wraps when it hits the end of a line? Does line-breaking wrap whole 'words' at a time, or characters, or something else (such as syllables in Tibetan and Javanese)?  What characters should not appear at the end or start of a line, and what should be done to prevent that? <a href="https://w3c.github.io/typography/index#line_breaking">See available information</a>.</p>
 
 
-    <p></p>
+<section id="linebreak_not_end_start">
+<h4>Characters Not Starting or Ending a Line</h4>
+    <p>Requirements in JLReq sections of <a href="https://w3c.github.io/jlreq/#characters-not-starting-a-line">Characters Not Starting a Line</a> and <a href="https://w3c.github.io/jlreq/#characters-not-ending-a-line">Characters Not Ending a Line</a> are implemented in <a href="https://drafts.csswg.org/css-text-3/#line-break-property">line-break property in css-text</a> and working ok.</p>
+    </section>
+
 </section>
 
 


### PR DESCRIPTION
 (waiting 3.1.10 for finishing this section)
draft for #113, hope it's fine...

- relevant tests are file basis, not listed in text (we haven't visited exact tests in wpt during discussion)
- open as 'needs research', since we haven't reached to 3.1.10