### PR TITLE
[simple-ruby] Fix a link to the figure

### DIFF
--- a/docs/simple-ruby/index.html
+++ b/docs/simple-ruby/index.html
@@ -512,7 +512,7 @@ it is explained last.</p>
     <a href="https://www.w3.org/TR/jlreq/#cl-26">Katakana (cl-16)</a>,
     <a href="https://www.w3.org/TR/jlreq/#cl-19">Ideographic characters (cl-19)</a> [[JLREQ]],
     and so on,
-    the placement depends on the following (see <a href="#protruding-group"></a>):
+    the placement depends on the following (see <a href="#ruby-west"></a>):
     <ul>
       <li>When their respective lengths would be the same,
         both are laid out without inter-letter spacing
@@ -528,10 +528,6 @@ it is explained last.</p>
         The size of the space inserted between each of the base characters
         is twice the size of the space inserted at the end and at the start.</li>
     </ul>
-    <figure id=protruding-group>
-      <img src="img/fig14.svg" />
-      <figcaption>Example of protruding group-ruby</figcaption>
-    </figure>
   </li>
   <li>
     <p>When the ruby string is longer than the base character string and protrudes,
@@ -542,6 +538,10 @@ it is explained last.</p>
     Also, when the ruby string is longer than the base character string,
     protrudes, and is located at the start or end of the line,
     the processing is also identical to that of mono-ruby.</p>
+    <figure id=protruding-group>
+      <img src="img/fig14.svg" />
+      <figcaption>Example of protruding group-ruby</figcaption>
+    </figure>
   </li>
   <li>
     <p>In the case of group ruby,

--- a/docs/simple-ruby/index.html
+++ b/docs/simple-ruby/index.html
@@ -512,7 +512,7 @@ it is explained last.</p>
     <a href="https://www.w3.org/TR/jlreq/#cl-26">Katakana (cl-16)</a>,
     <a href="https://www.w3.org/TR/jlreq/#cl-19">Ideographic characters (cl-19)</a> [[JLREQ]],
     and so on,
-    the placement depends on the following (see <a href="#ruby-west"></a>):
+    the placement depends on the following (see <a href="#protruding-group"></a>):
     <ul>
       <li>When their respective lengths would be the same,
         both are laid out without inter-letter spacing


### PR DESCRIPTION
This PR fixes a link to the figure in the 3rd point of the [group-ruby](https://w3c.github.io/jlreq/docs/simple-ruby/#placement-of-group-ruby-0) section. The text below seems to refer to Figure 14 (example of protruding group-ruby), rather than Figure 13 (example of ruby with western characters).