### PR TITLE
modified div to p for terminology table

### DIFF
--- a/index.html
+++ b/index.html
@@ -23053,16 +23053,16 @@
           <td>通しノンブル</td>
           <td>tōshi nonburu<br/>とおしのんぶる</td>
           <td>
-            <div its-locale-filter-list="en" lang="en">
-              <div>a) To number the pages of a book continuously across all those in the front matter, the text and the back matter.</div>
-              <div>b) To number the pages continuously across those of all books, such as a series published in separate volumes. Also to number the pages continuously across those of all issues of a periodical published in a year, aside from pagination per issue.</div>
-              <div>(JIS Z 8125)</div>
-            </div>
-            <div its-locale-filter-list="ja" lang="ja">
-                <div>a）<span class="term_listbody">書籍の前付・本文・後付を通して一連のノンブルを付けること．</span></div>
-                <div>b）<span class="term_listbody">分冊して刊行される叢書などで，それら全体を通して一連のノンブルを付けること．また，定期刊行物での各号ごとのノンブルとは別に1年分を通したノンブルを併記すること．</span></div>
-                <div>（JIS Z 8125）</div>
-            </div>
+            <p its-locale-filter-list="en" lang="en">
+              a) To number the pages of a book continuously across all those in the front matter, the text and the back matter.<br>
+              b) To number the pages continuously across those of all books, such as a series published in separate volumes. Also to number the pages continuously across those of all issues of a periodical published in a year, aside from pagination per issue.<br>
+              (JIS Z 8125)
+            </p>
+            <p its-locale-filter-list="ja" lang="ja">
+                a）<span class="term_listbody">書籍の前付・本文・後付を通して一連のノンブルを付けること．</span><br>
+                b）<span class="term_listbody">分冊して刊行される叢書などで，それら全体を通して一連のノンブルを付けること．また，定期刊行物での各号ごとのノンブルとは別に1年分を通したノンブルを併記すること．</span><br>
+                （JIS Z 8125）
+            </p>
           </td>
         </tr>
         <tr id="term.cut-in-heading">
@@ -23178,16 +23178,16 @@
             <td>地</td>
             <td>chi<br/>ち</td>
             <td>
-              <div its-locale-filter-list="en" lang="en">
-                  <div>a) The bottom part of a book or a page.</div>
-                  <div>b) The bottom margin between the edge of a trimmed page and the hanmen (text area)</div>
-                  <div>(JIS Z 8125)</div>
-              </div>
-              <div its-locale-filter-list="ja" lang="ja">
-                  <div>a）<span class="term_listbody">本又はページの下部．</span></div>
-                  <div>b）<span class="term_listbody">ページの下部の仕上り線と版面までの余白部分．</span></div>
-                  <div>（JIS Z 8125）</div>
-              </div>
+              <p its-locale-filter-list="en" lang="en">
+                  a) The bottom part of a book or a page.<br>
+                  b) The bottom margin between the edge of a trimmed page and the hanmen (text area)<br>
+                  (JIS Z 8125)
+              </p>
+              <p its-locale-filter-list="ja" lang="ja">
+                  a）<span class="term_listbody">本又はページの下部．</span><br>
+                  b）<span class="term_listbody">ページの下部の仕上り線と版面までの余白部分．</span><br>
+                  （JIS Z 8125）
+              </p>
             </td>
           </tr>
           <tr id="term.footnote">
@@ -23204,16 +23204,16 @@
             <td>小口</td>
             <td>koguchi<br/>こぐち</td>
             <td>
-              <div its-locale-filter-list="en" lang="en">
-                  <div>a) The three front trimmed edges of pages in a book.</div>
-                  <div>b) The opposite sides of the gutter in a book.</div>
-                  <div>(JIS Z 8125)</div>
-              </div>
-              <div its-locale-filter-list="ja" lang="ja">
-                  <div>a）<span class="term_listbody">本のページの綴じていない三方の切り口．</span></div>
-                  <div>b）<span class="term_listbody">のどの反対側．</span></div>
-                  <div>（JIS Z 8125）</div>
-              </div>
+              <p its-locale-filter-list="en" lang="en">
+                  a) The three front trimmed edges of pages in a book.<br>
+                  b) The opposite sides of the gutter in a book.<br>
+                  (JIS Z 8125)
+              </p>
+              <p its-locale-filter-list="ja" lang="ja">
+                  a）<span class="term_listbody">本のページの綴じていない三方の切り口．</span><br>
+                  b）<span class="term_listbody">のどの反対側．</span><br>
+                  （JIS Z 8125）
+              </p>
             </td>
           </tr>
           <tr id="term.front-matter">
@@ -23230,14 +23230,14 @@
             <td>全角</td>
             <td>zenkaku<br/>ぜんかく</td>
             <td>
-              <div its-locale-filter-list="en" lang="en">
-                  <div>a) Relative index for the length which is equal to a given character size.</div>
-                  <div>b) Character frame which character advance is equal to the amount referred to as a). A full-width character frame is  square in shape by definition.</div>
-              </div>
-              <div its-locale-filter-list="ja" lang="ja">
-                  <div>a）<span class="term_listbody">文字サイズに等しい長さの相対単位．</span></div>
-                  <div>b）<span class="term_listbody">字幅がaである文字の外枠．この場合，文字の外枠は正方形になる．</span></div>
-              </div>
+              <p its-locale-filter-list="en" lang="en">
+                  a) Relative index for the length which is equal to a given character size.<br>
+                  b) Character frame which character advance is equal to the amount referred to as a). A full-width character frame is  square in shape by definition.
+              </p>
+              <p its-locale-filter-list="ja" lang="ja">
+                  a）<span class="term_listbody">文字サイズに等しい長さの相対単位．</span><br>
+                  b）<span class="term_listbody">字幅がaである文字の外枠．この場合，文字の外枠は正方形になる．</span>
+              </p>
             </td>
           </tr>
           <tr id="term.furigana">
@@ -23290,18 +23290,18 @@
             <td>のど</td>
             <td>nodo<br/>のど</td>
             <td>
-              <div its-locale-filter-list="en" lang="en">
-                  <div>a) The binding side of a spread of a book.</div>
-                  <div>b) The margin between the binding edge of a book and the hanmen (text area).</div>
-                  <div>c) The part of a book where all pages are bound together to the book spine.</div>
-                  <div>(JIS Z 8125)</div>
-              </div>
-              <div its-locale-filter-list="ja" lang="ja">
-                  <div>a）<span class="term_listbody">本を広げたとき，中央の綴じ目がある方向．</span></div>
-                  <div>b）<span class="term_listbody">中央の綴じ目と版面の余白部分．</span></div>
-                  <div>c）<span class="term_listbody">本の中身と背が接する部分．</span></div>
-                  <div>（JIS Z 8125）</div>
-              </div>
+              <p its-locale-filter-list="en" lang="en">
+                  a) The binding side of a spread of a book.<br>
+                  b) The margin between the binding edge of a book and the hanmen (text area).<br>
+                  c) The part of a book where all pages are bound together to the book spine.<br>
+                  (JIS Z 8125)
+              </p>
+              <p its-locale-filter-list="ja" lang="ja">
+                  a）<span class="term_listbody">本を広げたとき，中央の綴じ目がある方向．</span><br>
+                  b）<span class="term_listbody">中央の綴じ目と版面の余白部分．</span><br>
+                  c）<span class="term_listbody">本の中身と背が接する部分．</span><br>
+                  （JIS Z 8125）
+              </p>
             </td>
           </tr>
           <tr id="term.gyodori">
@@ -23363,16 +23363,16 @@
             <td>天</td>
             <td>ten<br/>てん</td>
             <td>
-              <div its-locale-filter-list="en" lang="en">
-                  <div>a) The top part of a book or a page.</div>
-                  <div>b) The top margin between the top edge of a trimmed page and the hanmen (text area)</div>
-                  <div>(JIS Z 8125)</div>
-              </div>
-              <div its-locale-filter-list="ja" lang="ja">
-                  <div>a）<span class="term_listbody">本又はページの上部．</span></div>
-                  <div>b）<span class="term_listbody">ページの上部の仕上り線と版面までの余白部分．</span></div>
-                  <div>（JIS Z 8125）</div>
-              </div>
+              <p its-locale-filter-list="en" lang="en">
+                  a) The top part of a book or a page.<br>
+                  b) The top margin between the top edge of a trimmed page and the hanmen (text area)<br>
+                  (JIS Z 8125)
+              </p>
+              <p its-locale-filter-list="ja" lang="ja">
+                  a）<span class="term_listbody">本又はページの上部．</span><br>
+                  b）<span class="term_listbody">ページの上部の仕上り線と版面までの余白部分．</span><br>
+                  （JIS Z 8125）
+              </p>
             </td>
           </tr>
           <tr id="term.heading">
@@ -23380,16 +23380,16 @@
             <td>見出し</td>
             <td>midashi<br/>みだし</td>
             <td>
-              <div its-locale-filter-list="en" lang="en">
-                  <div>a) A title of a paper or an article.</div>
-                  <div>b) A title for each section of a book, paper or article.</div>
-                  <div>(JIS Z 8125)</div>
-              </div>
-              <div its-locale-filter-list="ja" lang="ja">
-                  <div>a）<span class="term_listbody">論文，記事などの標題．</span></div>
-                  <div>b）<span class="term_listbody">本，論文，記事などの内容を区分して付けた標題．</span></div>
-                  <div>（JIS Z 8125）</div>
-              </div>
+              <p its-locale-filter-list="en" lang="en">
+                  a) A title of a paper or an article.<br>
+                  b) A title for each section of a book, paper or article.<br>
+                  (JIS Z 8125)
+              </p>
+              <p its-locale-filter-list="ja" lang="ja">
+                  a）<span class="term_listbody">論文，記事などの標題．</span><br>
+                  b）<span class="term_listbody">本，論文，記事などの内容を区分して付けた標題．</span><br>
+                  （JIS Z 8125）
+              </p>
             </td>
           </tr>
           <tr id="term.headnote">
@@ -23757,20 +23757,20 @@
             <td>本文</td>
             <td>honbun<br/>ほんぶん</td>
             <td>
-              <div its-locale-filter-list="en" lang="en">
-                  <div>a) The principal part of  a book, usually preceded by the front matter, followed by the back matter.</div>
-                  <div>b) The principal part of an article excluding figures, tables, heading, notes, leads and so on.</div>
-                  <div>c) The content of a page excluding running heads and page numbers.</div>
-                  <div>d) The net contents of a book excluding covers, end papers, insets and so on.</div>
-                  <div>(JIS Z 8125)</div>
-              </div>
-              <div its-locale-filter-list="ja" lang="ja">
-                  <div>a）<span class="term_listbody">書籍を構成する主要部分．通常，その前に前付，後には後付が付く．</span></div>
-                  <div>b）<span class="term_listbody">図版，表，見出し，注，リードなどを除いた記事の中の主要部分．</span></div>
-                  <div>c）<span class="term_listbody">ページ内の柱及びノンブルを除いた部分．</span></div>
-                  <div>d）<span class="term_listbody">表紙，見返し，投げ込みなどの付属物を除いた本の中身．</span></div>
-                  <div>（JIS Z 8125）</div>
-              </div>
+              <p its-locale-filter-list="en" lang="en">
+                  a) The principal part of  a book, usually preceded by the front matter, followed by the back matter.<br>
+                  b) The principal part of an article excluding figures, tables, heading, notes, leads and so on.<br>
+                  c) The content of a page excluding running heads and page numbers.<br>
+                  d) The net contents of a book excluding covers, end papers, insets and so on.<br>
+                  (JIS Z 8125)
+              </p>
+              <p its-locale-filter-list="ja" lang="ja">
+                  a）<span class="term_listbody">書籍を構成する主要部分．通常，その前に前付，後には後付が付く．</span><br>
+                  b）<span class="term_listbody">図版，表，見出し，注，リードなどを除いた記事の中の主要部分．</span><br>
+                  c）<span class="term_listbody">ページ内の柱及びノンブルを除いた部分．</span><br>
+                  d）<span class="term_listbody">表紙，見返し，投げ込みなどの付属物を除いた本の中身．</span><br>
+                  （JIS Z 8125）
+              </p>
             </td>
           </tr>
           <tr id="term.matrix">
@@ -23805,18 +23805,18 @@
             <td>混植</td>
             <td>konshoku<br/>こんしょく</td>
             <td>
-                <div its-locale-filter-list="en" lang="en">
-                    <div>a) To interleave Japanese text with Western text in a line (Japanese and Western mixed text composition).</div>
-                    <div> b) To compose text with different sizes of characters (mixed size composition).</div>
-                    <div> c) To compose text with different typefaces (mixed typeface composition).</div>
-                    <div>(JIS Z 8125)</div>
-                </div>
-                <div its-locale-filter-list="ja" lang="ja">
-                  <div>a）<span class="term_listbody">和文と欧文とを併用して組版すること（和欧文混植）．</span></div>
-                  <div>b）<span class="term_listbody">異なる大きさの文字を併用して組版すること（異サイズ混植）．</span></div>
-                  <div>c）<span class="term_listbody">異なる書体を使用して組版すること（異書体混植）．</span></div>
-                  <div>（JIS Z 8125）</div>
-              </div>
+                <p its-locale-filter-list="en" lang="en">
+                    a) To interleave Japanese text with Western text in a line (Japanese and Western mixed text composition).<br>
+                    b) To compose text with different sizes of characters (mixed size composition).<br>
+                    c) To compose text with different typefaces (mixed typeface composition).<br>
+                    (JIS Z 8125)
+                </p>
+                <p its-locale-filter-list="ja" lang="ja">
+                  a）<span class="term_listbody">和文と欧文とを併用して組版すること（和欧文混植）．</span><br>
+                  b）<span class="term_listbody">異なる大きさの文字を併用して組版すること（異サイズ混植）．</span><br>
+                  c）<span class="term_listbody">異なる書体を使用して組版すること（異書体混植）．</span><br>
+                  （JIS Z 8125）
+              </p>
             </td>
           </tr>
           <tr id="term.mono-ruby">
@@ -24319,16 +24319,16 @@
             <td>天付き</td>
             <td>tentsuki<br/>てんつき</td>
             <td>
-              <div its-locale-filter-list="en" lang="en">
-                  <div>a) To remove conditional space from opening brackets at a line head to align the line head to the ones of the adjacent lines.</div>
-                  <div> b) Not to add the default line head indent for the first line of a paragraph so as to align all line heads.</div>
-                  <div>(JIS Z 8125)</div>
-              </div>
-              <div its-locale-filter-list="ja" lang="ja">
-                  <div>a）<span class="term_listbody">行頭に位置した括弧類に二分の字幅のものなどを使用して，隣接する行の行頭とそろえること．</span></div>
-                  <div>b）<span class="term_listbody">段落最初の行において行頭の字下げを行わないで，隣接する行の行頭とそろえること．</span></div>
-                  <div>（JIS Z 8125）</div>
-              </div>
+              <p its-locale-filter-list="en" lang="en">
+                  a) To remove conditional space from opening brackets at a line head to align the line head to the ones of the adjacent lines.<br>
+                  b) Not to add the default line head indent for the first line of a paragraph so as to align all line heads.<br>
+                  (JIS Z 8125)
+              </p>
+              <p its-locale-filter-list="ja" lang="ja">
+                  a）<span class="term_listbody">行頭に位置した括弧類に二分の字幅のものなどを使用して，隣接する行の行頭とそろえること．</span><br>
+                  b）<span class="term_listbody">段落最初の行において行頭の字下げを行わないで，隣接する行の行頭とそろえること．</span><br>
+                  （JIS Z 8125）
+              </p>
             </td>
           </tr>
           <tr id="term.text-direction">


### PR DESCRIPTION
(proposal)
Modified every div in terminology table into p, and div inside to just line break (br).


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/himorin/jlreq/pull/144.html" title="Last updated on Dec 3, 2019, 5:27 AM UTC (019919f)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/jlreq/144/2eb71ac...himorin:019919f.html" title="Last updated on Dec 3, 2019, 5:27 AM UTC (019919f)">Diff</a>