### PR TITLE
201912 pre release check

### DIFF
--- a/index.html
+++ b/index.html
@@ -5634,7 +5634,8 @@
           <p id="cl-14-en" its-locale-filter-list="en" lang="en">Full-width ideographic space (cl-14)</p>
           <p id="cl-14-ja" its-locale-filter-list="ja" lang="ja">和字間隔（cl-14）</p>
         <div class="example">
-            <p its-locale-filter-list="en" lang="en">U+3000 IDEOGRAPHIC SPACE</p>
+            <p its-locale-filter-list="en" lang="en">U+3000 (IDEOGRAPHIC SPACE)</p>
+            <p its-locale-filter-list="ja" lang="ja">U+3000</p>
           </div>
         </li>
         <li id="id322">

--- a/index.html
+++ b/index.html
@@ -1959,7 +1959,7 @@
 
 
 
-<section>
+<section id="chapter_3">
   <h2 id="line-composition">
 <span its-locale-filter-list="en" lang="en">Line Composition</span>
 <span its-locale-filter-list="ja" lang="ja">行の組版処理</span>

--- a/index.html
+++ b/index.html
@@ -5635,7 +5635,7 @@
           <p id="cl-14-ja" its-locale-filter-list="ja" lang="ja">和字間隔（cl-14）</p>
         <div class="example">
             <p its-locale-filter-list="en" lang="en">U+3000 (IDEOGRAPHIC SPACE)</p>
-            <p its-locale-filter-list="ja" lang="ja">U+3000</p>
+            <p its-locale-filter-list="ja" lang="ja">U+3000 (IDEOGRAPHIC SPACE)</p>
           </div>
         </li>
         <li id="id322">

--- a/index.html
+++ b/index.html
@@ -1624,12 +1624,8 @@
       <div class="example">
         <p its-locale-filter-list="en" lang="en">Positioning a horizontal  running head above the top left corner (to <a href="#term.head" class="termref">head</a> and <a href="#term.fore-edge" class="termref">fore-edge</a>) of the kihon-hanmen in a typical vertically set book  (see [[[#fig1_30]]]).</p>
          <p its-locale-filter-list="ja" lang="ja">縦組の書籍で<a href="#term.head" class="termref">天</a>・<a href="#term.fore-edge" class="termref">小口</a>寄りに柱を横組にして配置した場合の例（[[[#fig1_30]]]）</p>
-      </div>
-      <div class="example">
         <p its-locale-filter-list="en" lang="en">9 points above the kihon-hanmen (vertical space) </p>
          <p its-locale-filter-list="ja" lang="ja">基本版面との上下方向の空き量は9ポイント（9ポアキ）</p>
-      </div>
-      <div class="example">
         <p its-locale-filter-list="en" lang="en">9 points from the left edge of the kihon-hanmen (horizontal space) </p>
          <p its-locale-filter-list="ja" lang="ja">基本版面との左右方向の空き量（<span class="index" id="d3e7930">入り</span>ともいう）は9ポイント（9ポアキ）</p>
       </div>

--- a/index.html
+++ b/index.html
@@ -1624,11 +1624,16 @@
       <div class="example">
         <p its-locale-filter-list="en" lang="en">Positioning a horizontal  running head above the top left corner (to <a href="#term.head" class="termref">head</a> and <a href="#term.fore-edge" class="termref">fore-edge</a>) of the kihon-hanmen in a typical vertically set book  (see [[[#fig1_30]]]).</p>
          <p its-locale-filter-list="ja" lang="ja">縦組の書籍で<a href="#term.head" class="termref">天</a>・<a href="#term.fore-edge" class="termref">小口</a>寄りに柱を横組にして配置した場合の例（[[[#fig1_30]]]）</p>
+      <ul>
+        <li id="id20200608001">
         <p its-locale-filter-list="en" lang="en">9 points above the kihon-hanmen (vertical space) </p>
          <p its-locale-filter-list="ja" lang="ja">基本版面との上下方向の空き量は9ポイント（9ポアキ）</p>
+         </li>
+         <li id="id20200608002">
         <p its-locale-filter-list="en" lang="en">9 points from the left edge of the kihon-hanmen (horizontal space) </p>
          <p its-locale-filter-list="ja" lang="ja">基本版面との左右方向の空き量（<span class="index" id="d3e7930">入り</span>ともいう）は9ポイント（9ポアキ）</p>
-      </div>
+         </li>
+        </ul>
       <figure id="fig1_30"> 
       <img its-locale-filter-list="en" src="images/img1_30.png" alt="Positioning of a running head (vertical writing mode)." width="254" height="435">
       <img its-locale-filter-list="ja" lang="ja" src="images_ja/img1_30.png" alt="柱の配置指定例 （縦組）" width="364" height="517">
@@ -1638,6 +1643,7 @@
         </figcaption>
 
       </figure>
+      </div>
       <p its-locale-filter-list="en" lang="en">The following recommendations should be taken into account when positioning running heads and page numbers with reference to the kihon-hanmen.</p>
       <p its-locale-filter-list="ja" lang="ja"><span class="index" id="d3e7968"><span class="index" id="d3e7969">柱及びノンブルの基本版面との位置関係</span></span>では，次のような点に注意する．</p>
       <ol>

--- a/local.css
+++ b/local.css
@@ -133,13 +133,13 @@ a .fig-title {
 a .figno:after {
 	content: '';
 	}
-ol li {
+ol > li {
 	list-style-type: lower-alpha;
 	}
-ol li li { 
+ol li ol > li { 
 	list-style-type: decimal;
 	}
-ol li li li {
+ol li li ol > li {
 	list-style-type: lower-roman;
 	}
 .hidden {

--- a/local.css
+++ b/local.css
@@ -142,6 +142,18 @@ ol li ol > li {
 ol li li ol > li {
 	list-style-type: lower-roman;
 	}
+.appendix ol > li {
+	list-style-type: decimal;
+	}
+.appendix ol li ol > li { 
+	list-style-type: lower-alpha;
+	}
+.appendix ol li li ol > li {
+	list-style-type: lower-roman;
+	}
+.appendix ol li li li ol > li {
+	list-style-type: decimal;
+	}
 .hidden {
 	display: none;
 	}


### PR DESCRIPTION
still working in progress. not for review now. (English version to end of chapter 2, as for now)

- section 2.4.2 d note 6 (id=n33): ul > li inside note are shown by number but not bullet
- section 2.6.1 example description right above figure 50: divided into three but original in one
- section 3: missing id chapter_3
- fixed list numbering order for appendix
- added blank Japanese example for 3.9.2 13 (cl-13)
- added missing lang selector for appendix F.5 (en-app6_5)

Open comments

- character tables in appendix should be center for character cell?
- need to write TBD in appendix J revision log section


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***

### :boom: Error: 500 Internal Server Error :boom: ###

[PR Preview](https://github.com/tobie/pr-preview#pr-preview) failed to build. _(Last tried on Jun 8, 2020, 2:00 PM UTC)_.

<details>
<summary>More</summary>


PR Preview relies on a number of web services to run. There seems to be an issue with the following one:

:rotating_light: [Spec Generator](https://www.w3.org/2015/labs/) - Spec Generator is the web service used to build specs that rely on ReSpec.

:link: [Related URL](https://labs.w3.org/spec-generator/?type=respec&url=https%3A%2F%2Frawcdn.githack.com%2Fhimorin%2Fjlreq%2F711b4606d2a85c909dec3b670f525013dc6bea7f%2Findex.html%3FisPreview%3Dtrue)

```
Navigation timeout of 30000 ms exceeded
```

_If you don't have enough information above to solve the error by yourself (or to understand to which web service the error is related to, if any), please [file an issue](https://github.com/tobie/pr-preview/issues/new?title=Error%20not%20surfaced%20properly&body=See%20w3c/jlreq%23146.)._
</details>
