### PR TITLE
Update the Japanese name of JISC

### DIFF
--- a/index.html
+++ b/index.html
@@ -284,7 +284,7 @@
       <p its-locale-filter-list="ja" lang="ja">JIS X 4051 : 2004 日本語文書の組版方法（<span class="english">Formatting rules for Japanese documents</span>）</p>
     </blockquote>
     <p its-locale-filter-list="en" lang="en"> JIS X 4051 is available from the Japan Standards Association (http://www.jsa.or.jp/), but a PDF version is not available from JSA. The PDF version is accessible from the Japanese Industrial Standards Committee site (http://www.jisc.go.jp/), however it is not possible to download it. </p>
-    <p its-locale-filter-list="ja" lang="ja"> JIS X 4051 は，日本規格協会（http://www.jsa.or.jp/）から入手できる（PDFデータの頒布はしていない）．ただし，日本工業標準調査会（http://www.jisc.go.jp/）で，この規格を検索することにより，PDFの閲覧が可能である（閲覧のみに限られる）．</p>
+    <p its-locale-filter-list="ja" lang="ja"> JIS X 4051 は，日本規格協会（http://www.jsa.or.jp/）から入手できる（PDFデータの頒布はしていない）．ただし，日本産業標準調査会（http://www.jisc.go.jp/）で，この規格を検索することにより，PDFの閲覧が可能である（閲覧のみに限られる）．</p>
   </section>
 </section>
 <section id="chapter_2">


### PR DESCRIPTION
日本工業標準調査会 was renamed to 日本産業標準調査会.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/jlreq/pull/148.html" title="Last updated on Dec 4, 2019, 9:35 AM UTC (b609e0c)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/jlreq/148/2eb71ac...b609e0c.html" title="Last updated on Dec 4, 2019, 9:35 AM UTC (b609e0c)">Diff</a>