### PR TITLE
Stop Making Respec generate "non-normative" messages

### DIFF
--- a/docs/simple-ruby/index.html
+++ b/docs/simple-ruby/index.html
@@ -65,7 +65,7 @@
   <p>The original Japanese version is <a href="https://florian.rivoal.net/ruby/ruby-rules-ja.pdf">available in PDF format</a>.</p>
 </section>
 	
-<section class=informative>
+<section>
 <h2 id=intro>Introduction</h2>
 
 <section>
@@ -154,7 +154,7 @@ Note that the terminology is based on that defined in
 </section>
 </section>
 
-<section class=informative>
+<section>
 <h2 id="matters-considered-by-the-simple-placement-rules">Matters considered by the simple placement rules</h2>
 
 <section>
@@ -630,7 +630,7 @@ it is explained last.</p>
 </section>
 </section>
 
-<section class=informative>
+<section>
 <h2 id="ruby-and-accessibility">Ruby and Accessibility</h2>
 
 <section>


### PR DESCRIPTION
The whole document is a note, so nothing is normative. These messages
are therefore confusing.

Closes #25