### PR TITLE
Add clarification to the introduction

### DIFF
--- a/docs/simple-ruby/index.html
+++ b/docs/simple-ruby/index.html
@@ -149,6 +149,9 @@ there are also practical limits to how complex the system can be
 in order to be practically implementable.</p>
 
 <p>The following is a proposal for a simple processing system. The target audience is implementers and specification writers.
+It is expected that a full system may be more complex that what is described here,
+both due to the interaction with other features or other writing systems,
+and because those designing such system may wish to provide alternative options.
 Note that the terminology is based on that defined in
 <a href="https://www.w3.org/TR/jlreq/"><abbr title="Requirements for Japanese Text Layout">JLReq</abbr></a> [[JLREQ]].</p>
 </section>


### PR DESCRIPTION
This leaves room for future extensions, manual overrides, and other
tweaks, while letting the document focus on the simple system without
getting into all sorts of corner cases and side discussions.

Closes #200