### PR TITLE
Fix translation of the note associated with figure 15

### DIFF
--- a/docs/simple-ruby/index.html
+++ b/docs/simple-ruby/index.html
@@ -550,8 +550,10 @@ it is explained last.</p>
     so there is no line wrapping opportunity inside either string.</p>
     <aside class=note title="Wrap opportunities in group-ruby">
       As group-ruby is treated as a unit, there is no wrap opportunity.
-      However, in some exceptional cases where it is wrapped,
-      it is then processed similarly to jukugo-ruby.
+      However, there are examples where allowing wrapping may be desirable.
+      In such cases, based on appropriate association of base characters and ruby characters,
+      handling the wrapping opportunities the same way the are handled for jukugo-ruby
+      may be appropriate.
       <figure id=wrap-group>
         <img src="img/fig15.svg" />
         <figcaption>Wrapping group-ruby</figcaption>


### PR DESCRIPTION
The original translation was problematic and not particularly faithful to
the original Japanese text, causing confusion and misunderstanding. This
should clear things up.

Closes #26
Closes #194