### PR TITLE
Use the `group` configuration option

### DIFF
--- a/index.html
+++ b/index.html
@@ -50,10 +50,8 @@
                 {   name:       "<span lang='ja'>阿南 康宏</span> (Yasuhiro Anan), (<span lang='ja'>第１版</span> 1st edition)",
                     company:    "Microsoft" },
           ],
-		wg:           "Internationalization Working Group",
-		wgURI:        "https://www.w3.org/International/core/",
+		group:        "i18n",
 		//wgPublicList: "public-i18n-cjk",
-        wgPatentURI:  "https://www.w3.org/2004/01/pp-impl/32113/status",
 		edDraftURI: "https://w3c.github.io/jlreq/", 
  		github: "w3c/jlreq",
 		};


### PR DESCRIPTION
The wg, wgId, wgURI, and wgPatentURI options are deprecated in favour of
“group”.

See https://lists.w3.org/Archives/Public/spec-prod/2020JulSep/0002.html


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***

### :boom: Error: 500 Internal Server Error :boom: ###

[PR Preview](https://github.com/tobie/pr-preview#pr-preview) failed to build. _(Last tried on Jul 23, 2020, 3:39 AM UTC)_.

<details>
<summary>More</summary>


PR Preview relies on a number of web services to run. There seems to be an issue with the following one:

:rotating_light: [Spec Generator](https://www.w3.org/2015/labs/) - Spec Generator is the web service used to build specs that rely on ReSpec.

:link: [Related URL](https://labs.w3.org/spec-generator/?type=respec&url=https%3A%2F%2Frawcdn.githack.com%2Fw3c%2Fjlreq%2F9d4b7407cf17f738d1b64f7f5f47191344662720%2Findex.html%3FisPreview%3Dtrue)

```
Navigation timeout of 30000 ms exceeded
```

_If you don't have enough information above to solve the error by yourself (or to understand to which web service the error is related to, if any), please [file an issue](https://github.com/tobie/pr-preview/issues/new?title=Error%20not%20surfaced%20properly&body=See%20w3c/jlreq%23227.)._
</details>
