### PR TITLE
post release change (previous*)

### DIFF
--- a/index.html
+++ b/index.html
@@ -13,8 +13,8 @@
       var respecConfig = {
           specStatus: "ED",
 		  //publishDate: "2015-07-30",
-         // previousPublishDate:  "2015-07-23",
-          //previousMaturity:  "FPWD",
+          previousPublishDate:  "2020-08-11",
+          previousMaturity:  "WG-NOTE",
 
           shortName:  "jlreq",
 		  noRecTrack: true,


### PR DESCRIPTION
Adding previousPublishDate and previousMaturity as https://www.w3.org/TR/2020/NOTE-jlreq-20200811/

(do we want to tag the released one with the real configurations?? - if so, we need to do before merging this PR)


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***

### :boom: Error: 500 Internal Server Error :boom: ###

[PR Preview](https://github.com/tobie/pr-preview#pr-preview) failed to build. _(Last tried on Aug 11, 2020, 5:52 AM UTC)_.

<details>
<summary>More</summary>


PR Preview relies on a number of web services to run. There seems to be an issue with the following one:

:rotating_light: [Spec Generator](https://www.w3.org/2015/labs/) - Spec Generator is the web service used to build specs that rely on ReSpec.

:link: [Related URL](https://labs.w3.org/spec-generator/?type=respec&url=https%3A%2F%2Frawcdn.githack.com%2Fhimorin%2Fjlreq%2Fb8a1c846b6cfebfee48791cf8352a38f5954e68e%2Findex.html%3FisPreview%3Dtrue)

```
Navigation timeout of 30000 ms exceeded
```

_If you don't have enough information above to solve the error by yourself (or to understand to which web service the error is related to, if any), please [file an issue](https://github.com/tobie/pr-preview/issues/new?title=Error%20not%20surfaced%20properly&body=See%20w3c/jlreq%23232.)._
</details>
