### PR TITLE
updated README.md with new format of home

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,9 +30,10 @@ Please use the [GitHub issue list](https://github.com/w3c/jlreq/issues) to repor
 
 言語の機能についての問題報告、議論、文書への意見については、[GitHub issue](https://github.com/w3c/jlreq/issues) にお願いします。([GitHub issues の利用](https://www.w3.org/International/i18n-activity/guidelines/issues.html)についての文書を参考ください。)
 
-Note that the public-jlreq-admin mailing list is used to send notification digests & meeting minutes. It is **not** for technical discussion.
+Note that the public-i18n-japanese mailing list is used to send notification digests & meeting minutes. It is **not** for technical discussion.
+(Some technical discussion takes place on that list for the Japanese language enablement, but it is **strongly preferred** to use GitHub issues whenever possible.)
 
-注: public-jlreq-admin メールリストは要約通知や議事録の送信先です。技術的議論のためでは**ありません**。
+注: public-i18n-japanese メールリストは要約通知や議事録の送信先です。技術的議論のためでは**ありません**。（多少の日本語組版に関する技術的議論が行われることはありますが、GitHub issuesを利用することが**強く推奨されます**。）
 
 **You may raise issues in Japanese, however any substantive discussions should be summarised in English at some point, so that non-Japanese speakers can follow the rationale and contribute comments.**
 
@@ -44,17 +45,17 @@ You can participate in the task force work at various levels. In order of increa
 
 このタスクフォースにはいくつかの立場で参加可能です。活動を活発にするために、追跡者、貢献者、参加者、編者、議長の分類があります。それぞれの詳細は、[参加の立場](https://www.w3.org/International/i18n-drafts/pages/task_force_roles)についてのリストを参照してください。
 
-**To just follow the work:** Rather than 'Watch' this repository, [subscribe](mailto:public-jlreq-admin-request@w3.org?subject=subscribe) to the [public-jlreq-admin](https://lists.w3.org/Archives/Public/public-jlreq-admin/) mailing list. That list is notified (no more than once a day, and in digest form), about changes to issues in this repository, but also about other W3C Working Group issues related to the Japanese writing systems.
+**To just follow the work:** Rather than 'Watch' this repository, [subscribe](mailto:public-i18n-japanese-request@w3.org?subject=subscribe) to the [public-i18n-japanese](https://lists.w3.org/Archives/Public/public-i18n-japanese/) mailing list. That list is notified (no more than once a day, and in digest form), about changes to issues in this repository, but also about other W3C Working Group issues related to the Japanese writing systems.
 
-**活動を追跡だけする場合:** このレポジトリを 'Watch' するよりも、[public-jlreq-admin](https://lists.w3.org/Archives/Public/public-jlreq-admin/) メーリングリストに[参加](mailto:public-jlreq-admin-request@w3.org?subject=subscribe)してください。このリストには、このレポジトリにある issue の更新のみでなく、他の W3C Working Group の日本語に関する issue についても送信されます (最大一日一度、ダイジェスト形式です)。
+**活動を追跡だけする場合:** このレポジトリを 'Watch' するよりも、[public-i18n-japanese](https://lists.w3.org/Archives/Public/public-i18n-japanese/) メーリングリストに参加してください。このリストには、このレポジトリにある issue の更新のみでなく、他の W3C Working Group の日本語に関する issue についても送信されます (最大一日一度、ダイジェスト形式です)。
 
 **To contribute content:** All contributors should read and agree with [CONTRIBUTING.md](CONTRIBUTING.md).
 
 **文書に貢献するには:** 全ての参加者は  [CONTRIBUTING.md](CONTRIBUTING.md) を読み、それに同意する必要があります。
 
-**To become a participant, editor, or chair:** contact [Richard Ishida](mailto:ishida@w3.org) or [木田泰夫 (Yasuo Kida)](mailto:kida@me.com). We welcome participation requests. In addition to discussions at [GitHub issues](https://github.com/w3c/jlreq/issues), this group operates discussion mailing list ([public-i18n-japanese](https://lists.w3.org/Archives/Public/public-i18n-japanese/)) in Japanese.
+**To become a participant, editor, or chair:** contact [Richard Ishida](mailto:ishida@w3.org) or [木田泰夫 (Yasuo Kida)](mailto:kida@me.com). We welcome participation requests.
 
-**参加者、編者、議長に興味がある方:** [Richard Ishida](mailto:ishida@w3.org) か [木田泰夫 (Yasuo Kida)](mailto:kida@me.com) に連絡してください。参加の申し込みを歓迎します。このグループでは、[GitHub issues](https://github.com/w3c/jlreq/issues)での議論に加えて、日本語での議論用メーリングリスト([public-i18n-japanese](https://lists.w3.org/Archives/Public/public-i18n-japanese/))を利用しています。
+**参加者、編者、議長に興味がある方:** [Richard Ishida](mailto:ishida@w3.org) か [木田泰夫 (Yasuo Kida)](mailto:kida@me.com) に連絡してください。参加の申し込みを歓迎します。
 
 To get an idea about what's involved, see  [Get involved with Language Enablement!](https://www.w3.org/International/i18n-drafts/pages/languagedev_participation). 
 
@@ -68,8 +69,7 @@ To get an idea about what's involved, see  [Get involved with Language Enablemen
 
 
 ### Links to practical information (実用的な情報へのリンク)
-- [Mail archive (メールリストアーカイブ)](https://lists.w3.org/Archives/Public/public-jlreq-admin/)
-- [Discussion list mail archive (グループ内議論メールリストのアーカイブ)](https://lists.w3.org/Archives/Public/public-i18n-japanese/)
+- [Mail archive (メールリストアーカイブ)](https://lists.w3.org/Archives/Public/public-i18n-japanese/)
 - [Writing i18n tests (国際化関連テストを作成するには)](https://github.com/w3c/i18n-activity/wiki/Writing-i18n-tests)
 - [Practical tips for task forces (タスクフォースの実用的 tips)](https://www.w3.org/International/i18n-activity/guidelines/process.html) (See also the github and editorial guidelines below)
 - [Meeting info (定例会議情報)](https://www.w3.org/2021/04/jlreq-meeting-info.html)

--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ You can participate in the task force work at various levels. In order of increa
 
 To get an idea about what's involved, see  [Get involved with Language Enablement!](https://www.w3.org/International/i18n-drafts/pages/languagedev_participation). 
 
+どのような活動を行っているかについての詳細は、[言語を利用可能にする活動に参加する！](https://www.w3.org/International/i18n-drafts/pages/languagedev_participation)を参照ください。
 
 ### Contacts（連絡先）
 

--- a/README.md
+++ b/README.md
@@ -1,90 +1,86 @@
-# Japanese Text Layout task force (jlreq) （JLReq 日本語組版タスクフォース）
+# Japanese Language Enablement (jlreq)（JLReq 日本語組版要件）
 
-This group allows a network of experts to share information about gaps and requirements for support of Japanese on the Web and in eBooks. 
+This is the place to explore gaps in support for the Japanese script on the Web and in eBooks, and to document requirements.
 
-JLReq タスクフォースは、Web や eBook で日本語をサポートするための要件と現実のギャップ (gap) や要件 (requirements) 自体について、エキスパートの人たちが知識を交換・共有するために作りました。
+日本語をウェブや eBook で利用可能にするためのギャップ解析を行い、また要件を文書化するための場所です。
 
-A significant problem faced by the Web is that experts don't know how to tell the W3C what problems exist for support of their script or language, and the W3C doesn't know how to contact people who can help when questions arise. This network of experts should help to significantly reduce that problem. 
+We aim to address the problem that local users don't know how to tell the W3C what problems exist for support of their language on the Web, and the W3C doesn't know how to contact people who can help when questions arise.
 
-Web が抱えている大きな問題の一つは、エキスパートが彼らの言語のサポートにどのような問題があるかを W3C に伝える方法を知らないこと、反対に、W3C側から聞きたいことがあっても誰に聞けば良いのかが判らないことです。このエキスパートのグループがその問題を大きく解決することを期待しています。
+言語の利用者がウェブ上でその言語を利用できるようになるにはどのような問題があるかを W3C に伝える方法を知らないこと、また W3C で疑問が出たときに誰に聴けばよいかわからないという問題があり、それを解決しようとしています。
 
-Some experts go a step further, and contribute to the gap-analysis or requirements document, or to other documents produced by the group.
+Topics for discussion are suggested by [the gap-analysis template](https://www.w3.org/International/i18n-activity/templates/gap-analysis/gap-analysis_template.html). This work feeds into the [language matrix](https://www.w3.org/International/typography/gap-analysis/language-matrix.html) which provides a heat-map for language issues on the Web.
 
-一部のエキスパートの人たちは、一歩進んでこのグループが作成する成果物、例えばギャップの分析や要件定義の文書、その他の文書の作成などに貢献します。
+論点は[ギャップ解析のテンプレート](https://www.w3.org/International/i18n-activity/templates/gap-analysis/gap-analysis_template.html)にまとめられています。議論の結果はウェブでの言語に関する問題についてのヒートマップである[言語マトリクス](https://www.w3.org/International/typography/gap-analysis/language-matrix.html)にも反映されます。
 
-Topics for discussion are suggested by [the gap-analysis document](https://w3c.github.io/jlreq/gap-analysis/). This work supports the development of the [language matrix](https://w3c.github.io/typography/gap-analysis/language-matrix.html) which indicates hot-spots for language support. You can find a list of open issues, including those from Working Groups, on the [Layout Tracker](http://w3c.github.io/i18n-activity/textlayout/?filter=jlreq) page. (That link applies a `jlreq` filter.)
+### Key links (重要なリンク)
+[GitHub repo](https://github.com/w3c/jlreq) • [Discussion threads (議論のリスト)](https://github.com/w3c/jlreq/issues) • [Issue tracker (論点追跡リスト)](https://www.w3.org/International/i18n-activity/textlayout/?filter=jlreq) (with jlreq filter、`jlreq`でのフィルター) • [Charter (活動憲章)](https://www.w3.org/International/jlreq/charter/)
 
-この場で主に議論すべき項目はギャップ分析文書 [the gap-analysis document](https://w3c.github.io/jlreq/gap-analysis/) に示されています。その結果は言語サポートにおける重要課題 (hot-spot) を示す [language matrix](https://w3c.github.io/typography/gap-analysis/language-matrix.html) の開発に貢献します。JLReq タスクフォースや他の Working Group の日本語に関する未解決の問題（open issues）は [Layout Tracker](http://w3c.github.io/i18n-activity/textlayout/?filter=jlreq) のページで見ることができます。(このリンクのリストは `jlreq` でフィルターされたものです。)
+### Documents （文書）
+- [**Japanese Gap Analysis （日本語ギャップ分析）**](https://www.w3.org/TR/jpan-gap) • [*Editor's draft (編集草案)*](https://www.w3.org/International/jlreq/gap-analysis/) • [*Latest commits (直近の更新)*](https://github.com/w3c/jlreq/commits/gh-pages/gap-analysis/index.html) • [*Edit on GitHub (GitHub上の問題点リストの編集)*](https://github.com/w3c/jlreq/labels/doc%3Ajlreq)
+- [**Requirements for Japanese Text Layout (日本語組版処理の要件)**](https://www.w3.org/TR/jlreq) • [*Editor's draft (編集草案)*](https://www.w3.org/International/jlreq/) • [*Latest commits (直近の更新)*](https://github.com/w3c/jlreq/commits/gh-pages/index.html)
+- [**Rules for Simple Placement of Japanese Ruby (ルビの簡便な配置ルール)**](https://www.w3.org/TR/simple-ruby/) • [*Editor's draft (編集草案)*](https://w3c.github.io/simple-ruby/) • [*Latest commits (直近の更新)*](https://github.com/w3c/simple-ruby/commits/gh-pages/index.html)
 
-The focus is especially on typographic features for which information in English is hard to find, such as justification, letter-spacing, vertical text, text decoration, page layout, emphasis, etc.   We want to ensure that we have captured local user needs in CSS, HTML, Timed Text, Web Payments, Web Publishing, and the many other specifications that the W3C produces. 
-
-議論において特に重要なのは英語で情報を得ることの難しい組版の機能についてです。例えば行揃え、文字間隔、縦書き、文字の修飾、ページ構成、強調の方法、等です。W3C は W3C が開発するさまざまな仕様書、例えば CSS, HTML, Timed Text, Web Payments, Web Publishing 等が、それぞれの地域で必要な機能を必ず取り込んでいるようにしたいと考えています。
-
-### Documents（文書）
-- [Japanese Gap Analysis](https://w3c.github.io/jlreq/gap-analysis/) （日本語ギャップ分析） 
-- [Requirements for Japanese Text Layout](https://w3c.github.io/jlreq/) (Editor's copy)
-- [Requirements for Japanese Text Layout](https://www.w3.org/TR/jlreq/) (Working Group Note)
-- [Requirements for Japanese Text Layout](https://www.w3.org/TR/jlreq/?lang=ja) (Japanese version、日本語版)
-- [Rules for Simple Placement of Japanese Ruby](https://w3c.github.io/simple-ruby/)
-
-### Related documents
+### Related documents (関連文書)
 - [Current Status of Japanese Typography Using Web Technologies](https://www.w3.org/Submission/2017/SUBM-CSJTUWT-20170102/)
 - [Ready-made Counter Styles](https://www.w3.org/TR/predefined-counter-styles/)
 
+
 ### Feedback
-Please use the [GitHub issue](https://github.com/w3c/jlreq/issues) to report issues for language support, for discussions, and to send feedback about documents. (Learn [how GitHub issues work](http://w3c.github.io/i18n-activity/guidelines/issues.html).)
+Please use the [GitHub issue list](https://github.com/w3c/jlreq/issues) to report issues for language support, for discussions, and to send feedback about documents. (Learn [how GitHub issues work](https://www.w3.org/International/i18n-activity/guidelines/issues.html).)
 
-言語の機能についての問題報告、議論、文書への意見については、[GitHub issue](https://github.com/w3c/jlreq/issues) にお願いします。([GitHub issues の利用](http://w3c.github.io/i18n-activity/guidelines/issues.html)についての文書を参考ください。)
+言語の機能についての問題報告、議論、文書への意見については、[GitHub issue](https://github.com/w3c/jlreq/issues) にお願いします。([GitHub issues の利用](https://www.w3.org/International/i18n-activity/guidelines/issues.html)についての文書を参考ください。)
 
-Note: The public-i18n-cjk mailing list is used to send notification digests & meeting minutes. It is **not** for technical discussion.
+Note that the public-jlreq-admin mailing list is used to send notification digests & meeting minutes. It is **not** for technical discussion.
 
-注: public-i18n-cjk メールリストは要約通知や議事録の送信先です。技術的議論のためでは**ありません**。
+注: public-jlreq-admin メールリストは要約通知や議事録の送信先です。技術的議論のためでは**ありません**。
 
 **You may raise issues in Japanese, however any substantive discussions should be summarised in English at some point, so that non-Japanese speakers can follow the rationale and contribute comments.**
 
 **GitHub issues での議論は日本語で構いません。ただし重要な議論が日本語で行われた場合は、日本語の判らないメンバーが議論を理解しコメントできるよう、適当な時点で英語での要約が必要です。**
 
-### Participate (参加する方法)
-You can participate in the task force work at various levels. In order of increasing commitment, these include Follower, Contributor, Participant, Editor, and Chair. [Find your level](https://github.com/w3c/i18n-activity/wiki/Layout-task-force-roles).
 
-このタスクフォースにはいくつかの立場で参加可能です。活動を活発にするために、追跡者、貢献者、参加者、編者、議長の分類があります。それぞれの詳細は、[参加の立場](https://github.com/w3c/i18n-activity/wiki/Layout-task-force-roles)についてのリストを参照してください。
+### Participate  (参加する方法)
+You can participate in the task force work at various levels. In order of increasing commitment, these include Follower, Contributor, Participant, Editor, and Chair. [Find your level](https://www.w3.org/International/i18n-drafts/pages/task_force_roles).
 
-**To just follow the work:** Rather than 'Watch' this repository, subscribe to the [public-i18n-cjk](https://lists.w3.org/Archives/Public/public-i18n-cjk/) mailing list. That list is notified (no more than once a day, and in digest form), about changes to issues in this repository, but also about other W3C Working Group issues related to the Japanese, Chinese, & Korean writing systems.
+このタスクフォースにはいくつかの立場で参加可能です。活動を活発にするために、追跡者、貢献者、参加者、編者、議長の分類があります。それぞれの詳細は、[参加の立場](https://www.w3.org/International/i18n-drafts/pages/task_force_roles)についてのリストを参照してください。
 
-**活動を追跡だけする場合:** このレポジトリを 'Watch' するよりも、[public-i18n-cjk](https://lists.w3.org/Archives/Public/public-i18n-cjk/) メーリングリストに参加してください。このリストには、このレポジトリにある issue の更新のみでなく、他の W3C Working Group の日本語・中国語・韓国語に関する issue についても送信されます (最大一日一度、ダイジェスト形式です)。
+**To just follow the work:** Rather than 'Watch' this repository, [subscribe](mailto:public-i18n-japanese-request@w3.org?subject=subscribe) to the [public-i18n-japanese](https://lists.w3.org/Archives/Public/public-i18n-japanese/) mailing list. That list is notified (no more than once a day, and in digest form), about changes to issues in this repository, but also about other W3C Working Group issues related to the Japanese writing systems.
+
+**活動を追跡だけする場合:** このレポジトリを 'Watch' するよりも、[public-i18n-japanese](https://lists.w3.org/Archives/Public/public-i18n-japanese/) メーリングリストに参加してください。このリストには、このレポジトリにある issue の更新のみでなく、他の W3C Working Group の日本語に関する issue についても送信されます (最大一日一度、ダイジェスト形式です)。
 
 **To contribute content:** All contributors should read and agree with [CONTRIBUTING.md](CONTRIBUTING.md).
 
 **文書に貢献するには:** 全ての参加者は  [CONTRIBUTING.md](CONTRIBUTING.md) を読み、それに同意する必要があります。
 
-**To become a participant, editor, or chair:** contact [Richard Ishida](mailto:ishida@w3.org) or [木田泰夫 (Yasuo Kida)](mailto:kida@me.com). We welcome participation requests. 
+**To become a participant, editor, or chair:** contact [Richard Ishida](mailto:ishida@w3.org) or [木田泰夫 (Yasuo Kida)](mailto:kida@me.com). We welcome participation requests.
 
 **参加者、編者、議長に興味がある方:** [Richard Ishida](mailto:ishida@w3.org) か [木田泰夫 (Yasuo Kida)](mailto:kida@me.com) に連絡してください。参加の申し込みを歓迎します。
 
+To get an idea about what's involved, see  [Get involved with Language Enablement!](https://www.w3.org/International/i18n-drafts/pages/languagedev_participation). 
+
+
 ### Contacts（連絡先）
 
-Chair: [木田泰夫 (Yasuo Kida)](mailto:kida@me.com) • W3C staff: [下農淳司 (Atsushi Shimono)](mailto:atsushi@w3.org), [Richard Ishida](mailto:ishida@w3.org)
+- Chair (議長):  [木田泰夫 (Yasuo Kida)](mailto:kida@me.com)
+- W3C staff: [下農淳司 (Atsushi Shimono)](mailto:atsushi@w3.org), [Richard Ishida](mailto:ishida@w3.org)
+- [Group participants (グループ参加者一覧)](https://www.w3.org/groups/tf/i18n-jlreq/participants)
 
-### Links（JLReq 関連のリンク）
-- [Issue tracker](http://w3c.github.io/i18n-activity/textlayout/?filter=jlreq)
-- [Github issues](https://github.com/w3c/jlreq/issues)
-- [Charter](https://w3c.github.io/jlreq/charter/)
-- [List of group members](https://www.w3.org/2000/09/dbwg/details?group=109193&public=1)
-- Action tracker (tbd)
-- [How to contribute to a gap-analysis document](https://github.com/w3c/typography/blob/gh-pages/gap-analysis/HOWTO.md)
-- [Writing i18n tests](https://github.com/w3c/i18n-activity/wiki/Writing-i18n-tests)
-- [Practical tips for task forces](https://w3c.github.io/i18n-activity/guidelines/process.html)
-- Meeting info (tbd)
-- [public-i18n-japanese mail archive](https://lists.w3.org/Archives/Public/public-i18n-japanese/)
-- [public-i18n-cjk mail archive](https://lists.w3.org/Archives/Public/public-i18n-cjk/)
+
+### Links to practical information (実用的な情報へのリンク)
+- [Mail archive (メールリストアーカイブ)](https://lists.w3.org/Archives/Public/public-i18n-japanese/)
+- [Writing i18n tests (国際化関連テストを作成するには)](https://github.com/w3c/i18n-activity/wiki/Writing-i18n-tests)
+- [Practical tips for task forces (タスクフォースの実用的 tips)](https://www.w3.org/International/i18n-activity/guidelines/process.html) (See also the github and editorial guidelines below)
+
 
 ### Links to background information（W3C 国際化関連のリンク）
 The following information describes work going on at the W3C to support languages on the Web.
 
 下は W3C が web の国際化のために行なっている活動へのリンクです。
-- [Language matrix](http://w3c.github.io/typography/gap-analysis/language-matrix.html)
-- [Analysing support for text layout on the Web](https://github.com/w3c/i18n-discuss/wiki/Analysing-support-for-text-layout-on-the-Web)
-- [Overview of language enablement work in progress](https://www.w3.org/International/layout)
+
+- [Language support heatmap (matrix)](https://www.w3.org/International/typography/gap-analysis/language-matrix.html)
+- [Analysing support for text layout on the Web](https://www.w3.org/International/i18n-drafts/nav/languagedev)
+- [Overview of language enablement work in progress](https://www.w3.org/International/i18n-drafts/nav/languagedev)
+- [Get involved with Language Enablement](https://www.w3.org/International/i18n-drafts/pages/languagedev_participation)
 - [Setting up a Gap Analysis Project](https://github.com/w3c/typography/wiki/Setting-up-a-Gap-Analysis-Project)
 - [Internationalization Sponsorship Program](https://www.w3.org/International/sponsorship/)
 
@@ -93,14 +89,7 @@ The following information describes work going on at the W3C to support language
 If you end up creating a document, you should be familiar with and use the following:
 
 W3C の文書を作成するために知っておくべきこと：
-- [Github guidelines for working with i18n documents](http://w3c.github.io/i18n-activity/guidelines/github)
-- [Editorial guidelines for working with i18n documents](http://w3c.github.io/i18n-activity/guidelines/editing)
 
-The following templates are available:
-
-関連する文書テンプレート：
-- [Gap analysis template](http://w3c.github.io/i18n-activity/templates/gap-analysis/gap-analysis_template.html)
-- [Requirements document template](http://w3c.github.io/i18n-activity/templates/lreq_doc/gap-analysis_template.html)
-
-
+- [Github guidelines for working with i18n documents](https://www.w3.org/International/i18n-activity/guidelines/github)
+- [Editorial guidelines for working with i18n documents](https://www.w3.org/International/i18n-activity/guidelines/editing)
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 This is the place to explore gaps in support for the Japanese script on the Web and in eBooks, and to document requirements.
 
-日本語をウェブや eBook で利用可能にするためのギャップ解析を行い、また要件を文書化するための場所です。
+日本語をウェブや eBook で利用可能にするためのギャップ分析を行い、また要件を文書化するための場所です。
 
 We aim to address the problem that local users don't know how to tell the W3C what problems exist for support of their language on the Web, and the W3C doesn't know how to contact people who can help when questions arise.
 
@@ -10,7 +10,7 @@ We aim to address the problem that local users don't know how to tell the W3C wh
 
 Topics for discussion are suggested by [the gap-analysis template](https://www.w3.org/International/i18n-activity/templates/gap-analysis/gap-analysis_template.html). This work feeds into the [language matrix](https://www.w3.org/International/typography/gap-analysis/language-matrix.html) which provides a heat-map for language issues on the Web.
 
-論点は[ギャップ解析のテンプレート](https://www.w3.org/International/i18n-activity/templates/gap-analysis/gap-analysis_template.html)にまとめられています。議論の結果はウェブでの言語に関する問題についてのヒートマップである[言語マトリクス](https://www.w3.org/International/typography/gap-analysis/language-matrix.html)にも反映されます。
+論点は[ギャップ分析のテンプレート](https://www.w3.org/International/i18n-activity/templates/gap-analysis/gap-analysis_template.html)にまとめられています。議論の結果はウェブでの言語に関する問題についてのヒートマップである[言語マトリクス](https://www.w3.org/International/typography/gap-analysis/language-matrix.html)にも反映されます。
 
 ### Key links (重要なリンク)
 [GitHub repo](https://github.com/w3c/jlreq) • [Discussion threads (議論のリスト)](https://github.com/w3c/jlreq/issues) • [Issue tracker (論点追跡リスト)](https://www.w3.org/International/i18n-activity/textlayout/?filter=jlreq) (with jlreq filter、`jlreq`でのフィルター) • [Charter (活動憲章)](https://www.w3.org/International/jlreq/charter/)

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ To get an idea about what's involved, see  [Get involved with Language Enablemen
 - [Mail archive (メールリストアーカイブ)](https://lists.w3.org/Archives/Public/public-i18n-japanese/)
 - [Writing i18n tests (国際化関連テストを作成するには)](https://github.com/w3c/i18n-activity/wiki/Writing-i18n-tests)
 - [Practical tips for task forces (タスクフォースの実用的 tips)](https://www.w3.org/International/i18n-activity/guidelines/process.html) (See also the github and editorial guidelines below)
-
+- [Meeting info (定例会議情報)](https://www.w3.org/2021/04/jlreq-meeting-info.html)
 
 ### Links to background information（W3C 国際化関連のリンク）
 The following information describes work going on at the W3C to support languages on the Web.

--- a/README.md
+++ b/README.md
@@ -44,17 +44,17 @@ You can participate in the task force work at various levels. In order of increa
 
 このタスクフォースにはいくつかの立場で参加可能です。活動を活発にするために、追跡者、貢献者、参加者、編者、議長の分類があります。それぞれの詳細は、[参加の立場](https://www.w3.org/International/i18n-drafts/pages/task_force_roles)についてのリストを参照してください。
 
-**To just follow the work:** Rather than 'Watch' this repository, [subscribe](mailto:public-i18n-japanese-request@w3.org?subject=subscribe) to the [public-i18n-japanese](https://lists.w3.org/Archives/Public/public-i18n-japanese/) mailing list. That list is notified (no more than once a day, and in digest form), about changes to issues in this repository, but also about other W3C Working Group issues related to the Japanese writing systems.
+**To just follow the work:** Rather than 'Watch' this repository, [subscribe](mailto:public-jlreq-admin-request@w3.org?subject=subscribe) to the [public-jlreq-admin](https://lists.w3.org/Archives/Public/public-jlreq-admin/) mailing list. That list is notified (no more than once a day, and in digest form), about changes to issues in this repository, but also about other W3C Working Group issues related to the Japanese writing systems.
 
-**活動を追跡だけする場合:** このレポジトリを 'Watch' するよりも、[public-i18n-japanese](https://lists.w3.org/Archives/Public/public-i18n-japanese/) メーリングリストに参加してください。このリストには、このレポジトリにある issue の更新のみでなく、他の W3C Working Group の日本語に関する issue についても送信されます (最大一日一度、ダイジェスト形式です)。
+**活動を追跡だけする場合:** このレポジトリを 'Watch' するよりも、[public-jlreq-admin](https://lists.w3.org/Archives/Public/public-jlreq-admin/) メーリングリストに[参加](mailto:public-jlreq-admin-request@w3.org?subject=subscribe)してください。このリストには、このレポジトリにある issue の更新のみでなく、他の W3C Working Group の日本語に関する issue についても送信されます (最大一日一度、ダイジェスト形式です)。
 
 **To contribute content:** All contributors should read and agree with [CONTRIBUTING.md](CONTRIBUTING.md).
 
 **文書に貢献するには:** 全ての参加者は  [CONTRIBUTING.md](CONTRIBUTING.md) を読み、それに同意する必要があります。
 
-**To become a participant, editor, or chair:** contact [Richard Ishida](mailto:ishida@w3.org) or [木田泰夫 (Yasuo Kida)](mailto:kida@me.com). We welcome participation requests.
+**To become a participant, editor, or chair:** contact [Richard Ishida](mailto:ishida@w3.org) or [木田泰夫 (Yasuo Kida)](mailto:kida@me.com). We welcome participation requests. In addition to discussions at [GitHub issues](https://github.com/w3c/jlreq/issues), this group operates discussion mailing list ([public-i18n-japanese](https://lists.w3.org/Archives/Public/public-i18n-japanese/)) in Japanese.
 
-**参加者、編者、議長に興味がある方:** [Richard Ishida](mailto:ishida@w3.org) か [木田泰夫 (Yasuo Kida)](mailto:kida@me.com) に連絡してください。参加の申し込みを歓迎します。
+**参加者、編者、議長に興味がある方:** [Richard Ishida](mailto:ishida@w3.org) か [木田泰夫 (Yasuo Kida)](mailto:kida@me.com) に連絡してください。参加の申し込みを歓迎します。このグループでは、[GitHub issues](https://github.com/w3c/jlreq/issues)での議論に加えて、日本語での議論用メーリングリスト([public-i18n-japanese](https://lists.w3.org/Archives/Public/public-i18n-japanese/))を利用しています。
 
 To get an idea about what's involved, see  [Get involved with Language Enablement!](https://www.w3.org/International/i18n-drafts/pages/languagedev_participation). 
 
@@ -67,7 +67,8 @@ To get an idea about what's involved, see  [Get involved with Language Enablemen
 
 
 ### Links to practical information (実用的な情報へのリンク)
-- [Mail archive (メールリストアーカイブ)](https://lists.w3.org/Archives/Public/public-i18n-japanese/)
+- [Mail archive (メールリストアーカイブ)](https://lists.w3.org/Archives/Public/public-jlreq-admin/)
+- [Discussion list mail archive (グループ内議論メールリストのアーカイブ)](https://lists.w3.org/Archives/Public/public-i18n-japanese/)
 - [Writing i18n tests (国際化関連テストを作成するには)](https://github.com/w3c/i18n-activity/wiki/Writing-i18n-tests)
 - [Practical tips for task forces (タスクフォースの実用的 tips)](https://www.w3.org/International/i18n-activity/guidelines/process.html) (See also the github and editorial guidelines below)
 - [Meeting info (定例会議情報)](https://www.w3.org/2021/04/jlreq-meeting-info.html)


### PR DESCRIPTION
@kidayasuo we have a new format of our home, which will also be listed in w3.org/International/ site, currently placed as [home.md](https://github.com/w3c/jlreq/blob/gh-pages/home.md) in this repository. 
It seems there are several items need to be discussed, and I'm raising this PR (rather than updating #256).

- We have both -jlreq-admin and -i18n-japanese lists, and there are some lines to list these in new home.md. We need to decide which to list at where
  - -i18n-japanese is for discussions (mainly in Japanese), but I think we discussed to set this list public but not welcome subscribe for just watching?
  - -jlreq-admin is for administrative and posting summaries of discussions (for now)
- do we have tracker like [for arabic](https://www.w3.org/International/groups/arabic-layout/track/actions/open)? (I assume no)
- we don't have concrete plan of meetings (usually picking from Tue 10am JST), nor no meeting information page. Do we want to have a link of "Meeting Information"?

note: #256 will be merged after this PR landed.