### PR TITLE
Updating JL-TF charter

### DIFF
--- a/charter/index.html
+++ b/charter/index.html
@@ -81,7 +81,8 @@ src="https://www.w3.org/Icons/w3c_home" width="72" /></a></p>
 <p>The Japanese Text Layout Task Force will not produce Recommendation-track deliverables but will work on or produce documents that can be published by the Internationalization Working Group as Working Group Notes. Such work is expected to include the following. The completion of the work depends upon resource availability.</p>
 <ul>
 <li>Augment the contents of the <a href="https://www.w3.org/TR/jpan-gap/" rel="nofollow"> gap-analysis document</a>, which is one of many similar documents that radiate out from the <a href="https://www.w3.org/International/typography/gap-analysis/language-matrix.html" rel="nofollow">language matrix</a> to help us track areas where better support is needed. The gap analysis document uses a standard structure to list issues that content users and content authors face relating to particular apects of text layout, provide pointers to tests, and prioritise the importance of the barriers documented.</li>
-<li>Update the Japanese Layout Requirements document to fix errata, or improve the accessibility and user-friendliness of the document.</li>
+<li>Update the <a href="https://www.w3.org/TR/jlreq/">Japanese Layout Requirements</a> document to fix errata, or improve the accessibility and user-friendliness of the document.</li>
+<li>Update the <a href="https://www.w3.org/TR/simple-ruby/">Rules for Simple Placement of Japanese Ruby</a> document to fix errata.</li>
 <li>Produce other documents advising standards developers and application developers on how to cater for Japanese needs. Some of those documents may be developed elsewhere, such as at the Advanced Publishing Lab in Japan, and brought to this group for review and subsequent publication.</li>
 </ul>
 <p>The group may also choose to produce other non-normative deliverables, such as test cases and error reports – under the terms of the Policies for Contribution of Test Cases to W3C, and in coordination with any relevant working groups. 
@@ -166,6 +167,63 @@ created according to <a href="https://www.w3.org/Consortium/Process/groups#GAGen
   6.2</a> of the <a href="https://www.w3.org/Consortium/Process">Process Document</a>.  In the event
 of a conflict between this document or the provisions of any charter and the W3C Process, the W3C
 Process shall take precedence.</p>
+
+
+<h3 id="history">
+  Charter history
+</h3>
+<p>
+  The following table lists details of all changes from the initial
+  charter, per the <a href=
+  "https://www.w3.org/Consortium/Process/#CharterReview">W3C Process
+  Document (section 5.2.3)</a>:
+</p>
+<table class="history">
+  <tbody>
+    <tr>
+      <th>
+        Charter Period
+      </th>
+      <th>
+        Start Date
+      </th>
+      <th>
+        End Date
+      </th>
+      <th>
+        Changes
+      </th>
+    </tr>
+    <tr>
+      <th>
+        Initial charter
+      </th>
+      <td>
+        1 January 2019
+      </td>
+      <td>
+        31 December 2020
+      </td>
+      <td>
+        New task force created. <a href="https://www.w3.org/2007/02/japanese-layout/">Old Japanese Layout Task Force</a> had closed long before.
+      </td>
+    </tr>
+    <tr>
+      <th>
+        Rechartered
+      </th>
+      <td>
+      </td>
+      <td>
+        31 December 2022
+      </td>
+      <td>
+        Added <a href="https://www.w3.org/TR/simple-ruby/">Rules for Simple Placement of Japanese Ruby</a>.
+      </td>
+    </tr>
+  </tbody>
+</table>
+
 <hr />
 <address>
   Charter Authors:  Richard Ishida

--- a/charter/index.html
+++ b/charter/index.html
@@ -37,7 +37,7 @@ src="https://www.w3.org/Icons/w3c_home" width="72" /></a></p>
 <p class="mission">The Task Force is part of the W3C Internationalization Interest Group. The Task Force will report the results of its activities as a group back to the <a href="https://w3c.github.io/i18n-activity/i18n-wg/">W3C Internationalization Working Group</a>, as well as to other relevant groups and to the W3C membership and community.</p>
 <p class="mission">This charter is intended to reflect the current direction of the group, so that there is common agreement. It may be altered at any point in order to reflect new priorities or work items.</p>
 <div class="noprint">
-<p class="join"><a href="https://github.com/w3c/jlreq#following">Join the Japanese Text Layout Task Force</a>.</p>
+<p class="join"><a href="https://w3c.github.io/jlreq/home#participate--%E5%8F%82%E5%8A%A0%E3%81%99%E3%82%8B%E6%96%B9%E6%B3%95">Join the Japanese Text Layout Task Force</a>.</p>
 </div>
 <table class="summary-table">
   <tbody>
@@ -48,8 +48,7 @@ src="https://www.w3.org/Icons/w3c_home" width="72" /></a></p>
     <tr>
       <th rowspan="1" colspan="1">Confidentiality</th>
       <td rowspan="1" colspan="1">Proceedings are <a
-        href="https://www.w3.org/2005/10/Process-20051014/comm.html#confidentiality-levels"
-       >public </a></td>
+        href="https://www.w3.org/2020/Process-20200915/#confidentiality-levels">public</a></td>
     </tr>
     <tr>
       <th rowspan="1" colspan="1">Initial Chair</th>
@@ -73,15 +72,15 @@ src="https://www.w3.org/Icons/w3c_home" width="72" /></a></p>
 <h2 id="scope">Scope</h2>
 <p>This work aims to ensure that the W3C is developing a Web for All, with a particular emphasis on  Japan.</p>
 <p>The group exists to allow a network of experts to share information about gaps and requirements for support of Japanese on the Web and in digital publications.</p>
-<p>Topics for discussion are suggested by <a href="https://w3c.github.io/jlreq/gap-analysis/" rel="nofollow">the gap-analysis document</a>. This work supports the development of the <a href="https://w3c.github.io/typography/gap-analysis/language-matrix.html" rel="nofollow">matrix</a> indicating hot-spots for language support. The focus is especially on typographic features for which information in English is hard to find, such as justification, letter-spacing, vertical text, text decoration, page layout, emphasis, etc.   We want to ensure that we have captured local user needs in CSS, HTML, Timed Text, Web Payments, Web Publishing, and the many other specifications that the W3C produces.</p>
-<p>A significant problem faced by the Web is that experts don't know how to tell the W3C what problems exist for support of their script or language, and the W3C doesn't know how to contact people who can help when questions arise. This network of experts should help to significantly reduce that problem. They will be asked to consider and advise on issues that arise during the development of technologies at W3C. See the i18n WG's <a href="http://w3c.github.io/i18n-activity/textlayout/?filter=japanese">Layout tracker page</a> for examples of such issues.</p>
+<p>Topics for discussion are suggested by <a href="https://www.w3.org/TR/jpan-gap/" rel="nofollow">the gap-analysis document</a>. This work supports the development of the <a href="https://www.w3.org/International/typography/gap-analysis/language-matrix.html" rel="nofollow">matrix</a> indicating hot-spots for language support. The focus is especially on typographic features for which information in English is hard to find, such as justification, letter-spacing, vertical text, text decoration, page layout, emphasis, etc.   We want to ensure that we have captured local user needs in CSS, HTML, Timed Text, Web Payments, Web Publishing, and the many other specifications that the W3C produces.</p>
+<p>A significant problem faced by the Web is that experts don't know how to tell the W3C what problems exist for support of their script or language, and the W3C doesn't know how to contact people who can help when questions arise. This network of experts should help to significantly reduce that problem. They will be asked to consider and advise on issues that arise during the development of technologies at W3C. See the i18n WG's <a href="https://www.w3.org/International/i18n-activity/textlayout/">Layout tracker page</a> for examples of such issues.</p>
 <p>Experts who are <em>contributing</em> members of the task force will go a step further, and contribute to  documents produced by the group, as described in the section on deliverables below.</p>
 <p>The information produced in documents or discussed via GitHub issues needs to be relayed to the appropriate groups at W3C (and perhaps in other groups), and task force participants will probably want to be involved in those discussions. The notification framework already in place helps participants track issues raised against W3C working groups.</p>
 <div>
 <h2 id="deliverables">Deliverables</h2>
 <p>The Japanese Text Layout Task Force will not produce Recommendation-track deliverables but will work on or produce documents that can be published by the Internationalization Working Group as Working Group Notes. Such work is expected to include the following. The completion of the work depends upon resource availability.</p>
 <ul>
-<li>Augment the contents of the <a href="https://w3c.github.io/jlreq/gap-analysis/" rel="nofollow"> gap-analysis document</a>, which is one of many similar documents that radiate out from the <a href="https://w3c.github.io/typography/gap-analysis/language-matrix.html" rel="nofollow">language matrix</a> to help us track areas where better support is needed. The gap analysis document uses a standard structure to list issues that content users and content authors face relating to particular apects of text layout, provide pointers to tests, and prioritise the importance of the barriers documented.</li>
+<li>Augment the contents of the <a href="https://www.w3.org/TR/jpan-gap/" rel="nofollow"> gap-analysis document</a>, which is one of many similar documents that radiate out from the <a href="https://www.w3.org/International/typography/gap-analysis/language-matrix.html" rel="nofollow">language matrix</a> to help us track areas where better support is needed. The gap analysis document uses a standard structure to list issues that content users and content authors face relating to particular apects of text layout, provide pointers to tests, and prioritise the importance of the barriers documented.</li>
 <li>Update the Japanese Layout Requirements document to fix errata, or improve the accessibility and user-friendliness of the document.</li>
 <li>Produce other documents advising standards developers and application developers on how to cater for Japanese needs. Some of those documents may be developed elsewhere, such as at the Advanced Publishing Lab in Japan, and brought to this group for review and subsequent publication.</li>
 </ul>
@@ -102,16 +101,16 @@ src="https://www.w3.org/Icons/w3c_home" width="72" /></a></p>
     <dd>
       <ul>
         <li><a href="https://www.w3.org/International/">Internationalization Activity</a></li>
-        <li><a href="https://www.w3.org/Style/CSS/members">CSS Working Group</a></li>
-        <li><a href="https://www.w3.org/html/wg/">HTML Working Group</a></li>
-        <li><a href="https://www.w3.org/publishing/groups/publ-wg/">Publishing Working Group</a></li>
+        <li><a href="https://www.w3.org/Style/CSS/">CSS Working Group</a></li>
+        <li><a href="https://whatwg.org/">WHATWG</a></li>
+        <li><a href="https://www.w3.org/publishing/groups/epub-wg/">EPUB 3 Working Group</a></li>
         <li><a href="https://unicode.org/">Unicode Consortium</a></li>
-        <li><a href="https://www.w3.org/2011/08/browser-testing-charter.html">Browser Testing and Tools Working Group</a></li>
+        <li><a href="https://www.w3.org/testing/browser/">Browser Testing and Tools Working Group</a></li>
         <li><a href="https://www.w3.org/Graphics/SVG/">SVG Working Group</a></li>
-<li><a href="https://www.w3.org/AudioVideo/TT/">Timed Text Working Group</a></li> 
+        <li><a href="https://www.w3.org/AudioVideo/TT/">Timed Text Working Group</a></li> 
       </ul>
     </dd>
-    <dt>Other Groups</dt>
+  <dt>Other Groups</dt>
     <dd>The Japanese Text Layout Task Force is also expected to take advantage of opportunities for discussion and collaboration with existing groups and communities in Japanese-script countries as well as groups and communities elsewhere.</dd> 
 </dl>
 </div>
@@ -120,7 +119,7 @@ src="https://www.w3.org/Icons/w3c_home" width="72" /></a></p>
 <h2 id="participation">Participation</h2>
 
 <p>The Task Force provides for two levels of participation.</p>
-<p><strong>Followers</strong> are subscribed to the <a href="https://lists.w3.org/Archives/Public/public-i18n-cjk/" rel="nofollow">public-i18n-cjk</a> mailing list, where they can track discussions, and contribute opinions via the <a href="https://github.com/w3c/jlreq/issues">GitHub issue list</a>. Rather than just 'Watch' the GitHub repository, it is best to subscribe to the  mailing list, because that list is notified once a day (in digest form) about activity in the jlreq repository, but also about  activity for other W3C Working Group issues related to Japanese. (Participants are expected to use github issues rather than the mailing list to send feedback.)</p>
+<p><strong>Followers</strong> are subscribed to the <a href="https://lists.w3.org/Archives/Public/public-i18n-japanese/" rel="nofollow">public-i18n-japanese</a> mailing list, where they can track discussions, and contribute opinions via the <a href="https://github.com/w3c/jlreq/issues">GitHub issue list</a>. Rather than just 'Watch' the GitHub repository, it is best to subscribe to the  mailing list, because that list is notified once a day (in digest form) about activity in the jlreq repository, but also about  activity for other W3C Working Group issues related to Japanese. (Participants are expected to use github issues rather than the mailing list to send feedback.)</p>
 <p><strong>Task force members</strong> are expert contributors who participate actively in producing the work of the group, contributing text and advice to create the outputs, and participating in any meetings. These people are subscribed to the task force group by W3C staff.</p>
 <p>All TF members and people making contributions (via issues or pull requests) must read and agree with <a href="https://github.com/w3c/jlreq/blob/gh-pages/CONTRIBUTING.md">CONTRIBUTING.md</a>.</p>
 <p>Participants are reminded of the <a
@@ -132,8 +131,8 @@ Standing requirements</a> of the W3C Process.</p>
 <h2 id="communication">Communication</h2>
 
 <p>The <a href="https://github.com/w3c/jlreq">jlreq GitHub repository</a> and its issue list are the main vehicles for technical discussion. Discussion can be in Japanese and English but, where useful, Japanese discussions should be summarised in English when a conclusion is reached, so that the wider community can follow.</p>
-<p>The <a href="https://lists.w3.org/Archives/Public/public-i18n-cjk/">public-i18n-cjk@w3.org</a> list receives notifications of changes in the jlreq repository, and also of changes to issues in other repositories when those issues are tagged with a jlreq label. This includes the CSS and HTML repositories, amongst others. That mailing list should not be used for technical discussion. The public-i18n-cjk list must archive or point to minutes and summaries of all teleconferences and face-to-face meetings. Meeting minutes will list all attendees at a given meeting.</p>
-<p>An administrative list, <a href="https://lists.w3.org/Archives/Public/public-i18n-cjk/">public-jlreq-admin</a>, will  be used for internal communication about practical matters, such as meeting agenda, which should be published before each teleconference or face-to-face meeting.</p>
+<p>The <a href="https://lists.w3.org/Archives/Public/public-i18n-japanese/">public-i18n-japanese@w3.org</a> list receives notifications of changes in the jlreq repository, and also of changes to issues in other repositories when those issues are tagged with a jlreq label. This includes the CSS and HTML repositories, amongst others. That mailing list should not be used for technical discussion. The public-i18n-cjk list must archive or point to minutes and summaries of all teleconferences and face-to-face meetings. Meeting minutes will list all attendees at a given meeting.</p>
+<p>An administrative list, <a href="https://lists.w3.org/Archives/Public/public-jlreq-admin/">public-jlreq-admin</a>, will be used for internal communication about practical matters, such as meeting agenda, which should be published before each teleconference or face-to-face meeting.</p>
 
 <p>The group will use the <a href="https://www.w3.org/International/"> W3C Internationalization  home page </a>to provide updated public information about its activities.
 </p>
@@ -154,7 +153,7 @@ this group will seek to make decisions when there is consensus. In cases where t
 <div class="patent">
 <h2 id="patentpolicy">Patent Policy </h2>
 
-<p>Participants in the Japanese Text Layout Task Force are obligated to comply with W3C patent-disclosure policy as outlined  in <a href="https://www.w3.org/Consortium/Patent-Policy/#sec-Disclosure">Section 6</a> of the W3C Patent Policy document. Although the Japanese Text Layout Task Force is not chartered to produce Recommendation-track documents that themselves require patent disclosure, participants in the group are nevertheless obligated to comply with W3C patent-disclosure policy for any Recommendation-track specifications that they review or comment on.</p>
+<p>Participants in the Japanese Text Layout Task Force are obligated to comply with W3C patent-disclosure policy as outlined  in <a href="https://www.w3.org/Consortium/Patent-Policy-20200915/#sec-Disclosure">Section 6</a> of the W3C Patent Policy document. Although the Japanese Text Layout Task Force is not chartered to produce Recommendation-track documents that themselves require patent disclosure, participants in the group are nevertheless obligated to comply with W3C patent-disclosure policy for any Recommendation-track specifications that they review or comment on.</p>
         <p>For more information about disclosure obligations for this group, please see
 the <a href="https://www.w3.org/2004/01/pp-impl/">W3C Patent Policy
 Implementation</a>.</p>
@@ -172,17 +171,8 @@ Process shall take precedence.</p>
   Charter Authors:  Richard Ishida
 </address>
 
-<p class="copyright"><a rel="Copyright"
-href="https://www.w3.org/Consortium/Legal/ipr-notice#Copyright">Copyright</a> © 2018
-<a href="/"><abbr
-title="World Wide Web Consortium">W3C</abbr></a> <sup>®</sup> (<a
-href="http://www.csail.mit.edu/"><abbr
-title="Massachusetts Institute of Technology">MIT</abbr></a> , <a
-href="http://www.ercim.eu/"><abbr
-title="European Research Consortium for Informatics and Mathematics">ERCIM</abbr></a>
-, <a href="http://www.keio.ac.jp/">Keio</a>, 
- <a href="http://www.buaa.edu.cn/">Beihang</a>) All Rights
-Reserved.</p>
+<p class="copyright"> <a href="https://www.w3.org/Consortium/Legal/ipr-notice#Copyright">Copyright</a> © 2021 <a href="https://www.w3.org/"><abbr title="World Wide Web Consortium">W3C</abbr></a><sup>®</sup> ( <a href="https://www.csail.mit.edu/"><abbr title="Massachusetts Institute of Technology">MIT</abbr></a>, <a href="https://www.ercim.eu/"><abbr title="European Research Consortium for Informatics and Mathematics">ERCIM</abbr></a>, <a href="https://www.keio.ac.jp/">Keio</a>, <a href="https://ev.buaa.edu.cn/">Beihang</a> ), All Rights Reserved. <abbr title="World Wide Web Consortium">W3C</abbr> <a href="https://www.w3.org/Consortium/Legal/ipr-notice#Legal_Disclaimer">liability</a>, <a href="https://www.w3.org/Consortium/Legal/ipr-notice#W3C_Trademarks">trademark</a> and <a href="https://www.w3.org/Consortium/Legal/copyright-documents">document use</a> rules apply. </p>
+<hr>
 </div>
 </body>
 </html>

--- a/charter/index.html
+++ b/charter/index.html
@@ -43,7 +43,7 @@ src="https://www.w3.org/Icons/w3c_home" width="72" /></a></p>
   <tbody>
     <tr id="Duration">
       <th rowspan="1" colspan="1">End date</th>
-      <td rowspan="1" colspan="1">31 December 2020</td>
+      <td rowspan="1" colspan="1">31 December 2022</td>
     </tr>
     <tr>
       <th rowspan="1" colspan="1">Confidentiality</th>

--- a/charter/index.html
+++ b/charter/index.html
@@ -226,7 +226,7 @@ Process shall take precedence.</p>
 
 <hr />
 <address>
-  Charter Authors:  Richard Ishida
+  Charter Authors:  Richard Ishida, Atsushi Shimono
 </address>
 
 <p class="copyright"> <a href="https://www.w3.org/Consortium/Legal/ipr-notice#Copyright">Copyright</a> © 2021 <a href="https://www.w3.org/"><abbr title="World Wide Web Consortium">W3C</abbr></a><sup>®</sup> ( <a href="https://www.csail.mit.edu/"><abbr title="Massachusetts Institute of Technology">MIT</abbr></a>, <a href="https://www.ercim.eu/"><abbr title="European Research Consortium for Informatics and Mathematics">ERCIM</abbr></a>, <a href="https://www.keio.ac.jp/">Keio</a>, <a href="https://ev.buaa.edu.cn/">Beihang</a> ), All Rights Reserved. <abbr title="World Wide Web Consortium">W3C</abbr> <a href="https://www.w3.org/Consortium/Legal/ipr-notice#Legal_Disclaimer">liability</a>, <a href="https://www.w3.org/Consortium/Legal/ipr-notice#W3C_Trademarks">trademark</a> and <a href="https://www.w3.org/Consortium/Legal/copyright-documents">document use</a> rules apply. </p>


### PR DESCRIPTION
@kidayasuo as placeholder for discussion.

As for now, PR has a text with just added 2yrs to end date from [the current charter](https://www.w3.org/International/jlreq/charter/).

possible consideration points (as in chats):

- add recent new document like simple-ruby?
- add recent work on redefining JLReq using Unicode?
- more detailed description on gap-analysis and relevant tests work?