### PR TITLE
port scripts into respec post-script by promise

### DIFF
--- a/index.html
+++ b/index.html
@@ -6,7 +6,7 @@
 
 <link rel="stylesheet" href="local.css" />
 
-<script defer src="script.js"></script>
+<script src="script.js"></script>
 <script defer class="remove" src="https://www.w3.org/Tools/respec/respec-w3c"></script>
 
 <script class="remove">
@@ -54,12 +54,13 @@
 		//wgPublicList: "public-i18n-cjk",
 		edDraftURI: "https://w3c.github.io/jlreq/", 
  		github: "w3c/jlreq",
+        postProcess: [setFrontMatterIds],
 		};
     </script>
 </head>
 
 
-<body onload="setFrontMatterIds(); /*addLangAttrs();*/ initialiseLang()">
+<body>
 <h1 class="title p-name" id="title">Requirements for Japanese Text Layout <br/><span lang="ja">日本語組版処理の要件（日本語版）</span></h1>
 
 <div id="abstract">

--- a/index.html
+++ b/index.html
@@ -6,8 +6,8 @@
 
 <link rel="stylesheet" href="local.css" />
 
-<script async class="remove" src="https://www.w3.org/Tools/respec/respec-w3c"></script>
 <script defer src="script.js"></script>
+<script defer class="remove" src="https://www.w3.org/Tools/respec/respec-w3c"></script>
 
 <script class="remove">
       var respecConfig = {

--- a/index.html
+++ b/index.html
@@ -7,7 +7,7 @@
 <link rel="stylesheet" href="local.css" />
 
 <script src="script.js"></script>
-<script defer class="remove" src="https://www.w3.org/Tools/respec/respec-w3c"></script>
+<script defer id="js-respec" class="remove" src="https://www.w3.org/Tools/respec/respec-w3c"></script>
 
 <script class="remove">
       var respecConfig = {
@@ -54,7 +54,7 @@
 		//wgPublicList: "public-i18n-cjk",
 		edDraftURI: "https://w3c.github.io/jlreq/", 
  		github: "w3c/jlreq",
-        postProcess: [setFrontMatterIds],
+        postProcess: [ setFrontMatterIds, initialiseLang_p ],
 		};
     </script>
 </head>

--- a/script.js
+++ b/script.js
@@ -45,9 +45,9 @@ function switchLang (lang) {
 			document.querySelectorAll('figcaption').forEach(obj => obj.firstChild.textContent = translations['fig'][lang])
 		} else {
 			document.querySelectorAll('[its-locale-filter-list='+lang+']').forEach(obj => obj.classList.add('hidden'))
-		}
-	})
-}
+			}
+		})
+	}
 
 
 async function setFrontMatterIds() {

--- a/script.js
+++ b/script.js
@@ -1,138 +1,73 @@
-var translations = {
-	'en': {
-		'abstract': 'Abstract',
-		'sotd': 'Status of This Document',
-		'toc': 'Table of Contents',
-		'note': 'Note',
-		'fig': 'Figure ',
-		'thisversion': 'This version:',
-		'latestpublished': 'Latest published version:',
-		'editorsdraft': "Latest editor's draft:",
-		'previousversion': "Previous version:",
-		'author': 'Author:',
-		'authors': 'Authors:',
-		'editor': "Editor:",
-		'editors': "Editors:",
-		'formerEditor': "Former editor:",
-		'formerEditors': "Former editors:",
-		'participate': "Participate:",
-		'fileABug': "File a bug",
-		'commitHistory': "Commit history",
-		'pullRequests': "Pull requests"
-		},
-	'ja': {
-		'abstract': '要約',
-		'sotd': 'この文書の位置付け',
-		'toc': '目次',
-		'note': '注',
-		'fig': '図',
-		'thisversion': 'このバージョン：',
-		'latestpublished': '最新バージョン：',
-		'previousversion': "旧バージョン：",
-		'editorsdraft': "最新の編集用草案：",
-		'author': '著者：',
-		'authors': '著者：',
-		'editor': "編者：",
-		'editors': "編者：",
-		'formerEditor': "以前の版の編者：",
-		'formerEditors': "以前の版の編者：",
-		'participate': "参加方法：",
-		'fileABug': "問題報告",
-		'commitHistory': "変更履歴",
-		'pullRequests': "プルリクエスト"
-		},
-	}
+const translations = {
+	'abstract': {'en': 'Abstract', 'ja': '要約' },
+	'sotd': {'en': 'Status of This Document', 'ja': 'この文書の位置付け' },
+	'toc': {'en': 'Table of Contents', 'ja': '目次' },
+	'note': {'en': 'Note', 'ja': '注' },
+	'fig': {'en': 'Figure ', 'ja': '図' },
+	'thisversion': {'en': 'This version:', 'ja': 'このバージョン：' },
+	'latestpublished': {'en': 'Latest published version:', 'ja': '最新バージョン：' },
+	'editorsdraft': {'en': "Latest editor's draft:", 'ja': "最新の編集用草案：" },
+	'previousversion': {'en': "Previous version:", 'ja': "旧バージョン：" },
+	'author': {'en': 'Author:', 'ja': '著者：' },
+	'authors': {'en': 'Authors:', 'ja': '著者：' },
+	'editor': {'en': "Editor:", 'ja': "編者：" },
+	'editors': {'en': "Editors:", 'ja': "編者：" },
+	'formerEditor': {'en': "Former editor:", 'ja': "以前の版の編者：" },
+	'formerEditors': {'en': "Former editors:", 'ja': "以前の版の編者：" },
+	'participate': {'en': "Participate:", 'ja': "参加方法：" },
+	'fileABug': {'en': "File a bug", 'ja': "問題報告" },
+	'commitHistory': {'en': "Commit history", 'ja': "変更履歴" },
+	'pullRequests': {'en': "Pull requests", 'ja': "プルリクエスト" }
+}
 
 function switchLang (lang) {
-// hides all elements with its-locale-filter-list set to the other language
+	// hides all elements with its-locale-filter-list set to the other language
 
-    var langs = { 'ja': true, 'en':true } // en must come last (for all to work in front matter)
-	if (lang==='ja') langs.en = false
-	if (lang==='en') langs.ja = false
-	
-	// show all hidden elements
-	var els = document.querySelectorAll('.hidden')
-	for (var i=0;i<els.length;i++) els[i].classList.remove('hidden') 
+	// set lang
+	var langs = { 'ja': true, 'en':true } // en must come last (for all to work in front matter)
+	if (lang === 'ja') langs.en = false
+	if (lang === 'en') langs.ja = false
 
-	Object.keys(langs).forEach( function (lang) {
+	// show all
+	document.querySelectorAll('.hidden').forEach(obj => obj.classList.remove('hidden'));
+
+	Object.keys(langs).forEach(lang => {
 		if (langs[lang]) {
-			// set the default language in html tag
-			document.documentElement.lang = lang
-			
-			// change boilerplate text
-			document.getElementById('abstract').firstChild.textContent = translations[lang].abstract
-			document.getElementById('sotd').firstChild.textContent = translations[lang].sotd
-			document.getElementById('table-of-contents').textContent = translations[lang].toc
-
-			changeBoilerplate ('thisversion', lang);
-			changeBoilerplate ('latestpublished', lang);
-			changeBoilerplate ('editorsdraft', lang);
-			changeBoilerplate ('previousversion', lang);
-			changeBoilerplate ('editor', lang);
-			changeBoilerplate ('editors', lang);
-			changeBoilerplate ('formerEditor', lang);
-			changeBoilerplate ('formerEditors', lang);
-			changeBoilerplate ('participate', lang);
-			changeBoilerplate ('fileABug', lang);
-			changeBoilerplate ('commitHistory', lang);
-			changeBoilerplate ('pullRequests', lang);
-			
+			document.documentElement.lang = lang;
+			document.getElementById('abstract').firstChild.textContent = translations['abstract'][lang];
+			document.getElementById('sotd').firstChild.textContent = translations['sotd'][lang];
+			document.getElementById('table-of-contents').textContent = translations['toc'][lang];
+      let changeBoilerplate = function (obj) {if (obj.id) {obj.textContent = translations[obj.id][lang] }}
+			document.querySelectorAll('dt').forEach(obj => changeBoilerplate(obj))
+			document.querySelectorAll('.head a').forEach(obj => changeBoilerplate(obj))
 			// change note and figure titles
-			var notes = document.querySelectorAll('.note-title')
-			for (let i=0;i<notes.length;i++) notes[i].textContent = translations[lang].note
-			var figcaptions = document.querySelectorAll('figcaption')
-			for (let i=0;i<figcaptions.length;i++) figcaptions[i].firstChild.textContent = translations[lang].fig
-			}
-			
-		// hide relevant elements
-		else {
-			els = document.querySelectorAll('[its-locale-filter-list='+lang+']')
-			for (var i=0;i<els.length;i++) els[i].classList.add('hidden') 
-			}
-		})
-	}
-
-
-
-function setFrontMatterIds () {
-	// adds ids to dt elements in front matter to facilitate language switching
-	
-	var dts = document.querySelectorAll('dt')
-	for (let i=0;i<dts.length;i++) { 
-		switch (dts[i].textContent.trim()) {
-			case 'This version:': dts[i].id = "thisversion"; break;
-			case 'Latest published version:': dts[i].id = "latestpublished"; break;
-			case 'Previous version:': dts[i].id = "previousversion"; break;
-			case 'Latest editor\'s draft:': dts[i].id = "editorsdraft"; break;
-			case 'Authors:': dts[i].id = "authors"; break;
-			case 'Editor:': dts[i].id = "editor"; break;
-			case 'Editors:': dts[i].id = "editors"; break;
-			case 'Former editor:': dts[i].id = "formerEditor"; break;
-			case 'Former editors:': dts[i].id = "formerEditors"; break;
-			case 'Participate:': dts[i].id = "participate"; break;
-			}
+			document.querySelectorAll('.note-title').forEach(obj => obj.textContent = translations['note'][lang])
+			document.querySelectorAll('figcaption').forEach(obj => obj.firstChild.textContent = translations['fig'][lang])
+		} else {
+			document.querySelectorAll('[its-locale-filter-list='+lang+']').forEach(obj => obj.classList.add('hidden'))
 		}
-	var anchors = document.querySelectorAll('.head a')
-	for (let i=0;i<anchors.length;i++) {
-		switch (anchors[i].textContent) {
-			case 'File a bug': anchors[i].id = "fileABug"; break;
-			case 'Commit history': anchors[i].id = "commitHistory"; break;
-			case 'Pull requests': anchors[i].id = "pullRequests"; break;
-			}
-		}
-	}
+	})
+}
 
 
-function changeBoilerplate (id, lang, translationsid) {
-	if (translationsid === undefined) {
-		translationsid = id;
+async function setFrontMatterIds() {
+	// first constract reverse hash from en string to id
+	let en2id = [];
+	Object.keys(translations).forEach(key => en2id[translations[key]['en']] = key);
+	let addLangData = function (obj) {
+		let ctxt = obj.textContent.trim();
+		if (ctxt in en2id) {
+			obj.id = en2id[ctxt];
+			Object.keys(translations[obj.id]).forEach(langid => obj.dataset['loc_' + langid] = translations[obj.id][langid]);
+			delete en2id[ctxt]; // debugout
 		}
-	if (document.getElementById(id)) {
-		document.getElementById(id).textContent = translations[lang][translationsid]
-	} else {
-		console.log("%s does not exist.", id);
-		}
-	}
+	};
+	document.querySelectorAll('dt').forEach(obj => addLangData(obj))
+	document.querySelectorAll('.head a').forEach(obj => addLangData(obj))
+	console.log("Items not used:"); // debugout
+	Object.keys(en2id).forEach(key => console.log(en2id[key])); // debugout
+}
+
 	
 
 function addLangAttrs () { console.log("THIS FUNCTION IS NO LONGER NEEDED")
@@ -161,6 +96,7 @@ function initialiseLang () {
 			}
 		}
 	}
+window.addEventListener('DOMContentLoaded', initialiseLang());
 
 //figures = document.querySelectorAll('figure')
 //for (let i=0;i<figures.length;i++) console.log(figures[i].id)

--- a/script.js
+++ b/script.js
@@ -96,7 +96,8 @@ function initialiseLang () {
 			}
 		}
 	}
-window.addEventListener('DOMContentLoaded', () => { if (document.getElementById('js-respec')) {console.log('found'); } else {console.log('not-found'); initialiseLang(); }} );
+async function initialiseLang_p () { initialiseLang(); }
+window.addEventListener('DOMContentLoaded', () => { if (! document.getElementById('js-respec')) {initialiseLang(); }} );
 
 //figures = document.querySelectorAll('figure')
 //for (let i=0;i<figures.length;i++) console.log(figures[i].id)

--- a/script.js
+++ b/script.js
@@ -96,7 +96,7 @@ function initialiseLang () {
 			}
 		}
 	}
-window.addEventListener('DOMContentLoaded', initialiseLang());
+window.addEventListener('DOMContentLoaded', () => { if (document.getElementById('js-respec')) {console.log('found'); } else {console.log('not-found'); initialiseLang(); }} );
 
 //figures = document.querySelectorAll('figure')
 //for (let i=0;i<figures.length;i++) console.log(figures[i].id)


### PR DESCRIPTION
as proposal, closes #260

further items which could be investigated

- [x] (for use with respec) timing between initializeLang and respec processing: initializeLang need to run after respec
  - e.g. checking respec is loaded or not
- whether to divide functions needs to be persistent (inizializeLang and switchLang) and only used with respec (else)?
- [x] switchLang should have tri-state for langs array (not to run updating texts multiple times on 'all')
  - by measuring with `performance`, `switchLang` processing takes only around 100msec and possible duplicated part (replacing text in header part by suitable lnaguage's one) takes 1/3. so no much gain by this.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***

### :boom: Error: 500 Internal Server Error :boom: ###

[PR Preview](https://github.com/tobie/pr-preview#pr-preview) failed to build. _(Last tried on Apr 27, 2021, 5:49 AM UTC)_.

<details>
<summary>More</summary>


PR Preview relies on a number of web services to run. There seems to be an issue with the following one:

:rotating_light: [Spec Generator](https://www.w3.org/2015/labs/) - Spec Generator is the web service used to build specs that rely on ReSpec.

:link: [Related URL](https://labs.w3.org/spec-generator/?type=respec&url=https%3A%2F%2Frawcdn.githack.com%2Fhimorin%2Fjlreq%2F64655bd7e1eb876fd6acd8374eda9b21bb92164c%2Findex.html%3FisPreview%3Dtrue)

```
Navigation timeout of 29615 ms exceeded
```

_If you don't have enough information above to solve the error by yourself (or to understand to which web service the error is related to, if any), please [file an issue](https://github.com/tobie/pr-preview/issues/new?title=Error%20not%20surfaced%20properly&body=See%20w3c/jlreq%23264.)._
</details>


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***

### :boom: Error: 500 Internal Server Error :boom: ###

[PR Preview](https://github.com/tobie/pr-preview#pr-preview) failed to build. _(Last tried on Mar 4, 2024, 5:36 AM UTC)_.

<details>
<summary>More</summary>


PR Preview relies on a number of web services to run. There seems to be an issue with the following one:

:rotating_light: [Spec Generator](https://www.w3.org/2015/labs/) - Spec Generator is the web service used to build specs that rely on ReSpec.

:link: [Related URL]([object Object])

```
Navigation timeout of 28237 ms exceeded
```

_If you don't have enough information above to solve the error by yourself (or to understand to which web service the error is related to, if any), please [file an issue](https://github.com/tobie/pr-preview/issues/new?title=Error%20not%20surfaced%20properly&body=See%20w3c/jlreq%23264.)._
</details>
