### PR TITLE
inserted text on positioning of characters of ruby annotation on block direction

### DIFF
--- a/index.html
+++ b/index.html
@@ -3741,9 +3741,7 @@
           character frames of ruby annotation are contiguous with ones of its base text in the block direction.
           For visually handicapped person, there are cases to desire some spacing between two character frames in the block direction, 
           so it is desired to have capability to configure these spacing. </p>
-        <p its-locale-filter-list="ja" lang="ja">行送り方向のルビの配置位置は，親文字の文字の外枠とルビ文字の文字の外枠を接して配置するのが原則である．
-          しかし，視覚障碍者にとって，親文字とルビの行送り方向の間隔がある程度は空いているのが望ましい場合もあり，
-          この間隔は変更できることが望ましい．</p>        
+        <p its-locale-filter-list="ja" lang="ja">行送り方向のルビの配置位置は，親文字の文字の外枠とルビ文字の文字の外枠を接して配置するのが原則である．しかし，視覚障碍者にとって，親文字とルビの行送り方向の間隔がある程度は空いているのが望ましい場合もあり，この間隔は変更できることが望ましい．</p>        
       </aside>
       <p its-locale-filter-list="en" lang="en"> In the following sections, the ruby composition methods will be explained on the assumption that the size of ruby is half the size of the
         base characters, and they will be attached to the right in vertical writing mode and above in horizontal writing mode. First we look at

--- a/index.html
+++ b/index.html
@@ -3731,6 +3731,20 @@
         </figcaption>
 
       </figure>
+      <p its-locale-filter-list="en" lang="en">For positioning of characters of ruby annotation on block direction, 
+        character frames of ruby annotation are contiguous with ones of its base text ([[[#fig2_3_9]]]).</p>
+      <p its-locale-filter-list="ja" lang="ja">なお，ルビの行送り方向の配置位置は，親文字の文字の外枠とルビ文字の外枠を接して配置する（[[[#fig2_3_9]]]）．</p>
+      <aside class="note" id="n20211126001">
+        <p its-locale-filter-list="en" lang="en">Positioning of characters of ruby annotation on block direction</p>
+        <p its-locale-filter-list="ja" lang="ja">行送り方向のルビの配置位置</p>
+        <p its-locale-filter-list="en" lang="en">In generic principles, 
+          character frames of ruby annotation are contiguous with ones of its base text in the block direction.
+          For visually handicapped person, there are cases to desire some spacing between two character frames in the block direction, 
+          so it is desired to have capability to configure these spacing. </p>
+        <p its-locale-filter-list="ja" lang="ja">行送り方向のルビの配置位置は，親文字の文字の外枠とルビ文字の文字の外枠を接して配置するのが原則である．
+          しかし，視覚障碍者にとって，親文字とルビの行送り方向の間隔がある程度は空いているのが望ましい場合もあり，
+          この間隔は変更できることが望ましい．</p>        
+      </aside>
       <p its-locale-filter-list="en" lang="en"> In the following sections, the ruby composition methods will be explained on the assumption that the size of ruby is half the size of the
         base characters, and they will be attached to the right in vertical writing mode and above in horizontal writing mode. First we look at
         the basic composition rules of <a href="#term.mono-ruby" class="termref2nd">mono-ruby</a>, <a href="#term.group-ruby" class="termref2nd">group-ruby</a> and <a href="#term.jukugo-ruby" class="termref2nd">jukugo-ruby</a>, then the rules of positioning of ruby with respect to


### PR DESCRIPTION
/cc @KobayashiToshi 

Added text per comment provided.

closes #319


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/himorin/jlreq/pull/320.html" title="Last updated on Nov 27, 2021, 3:14 AM UTC (a965980)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/jlreq/320/0d75d01...himorin:a965980.html" title="Last updated on Nov 27, 2021, 3:14 AM UTC (a965980)">Diff</a>