### PR TITLE
possible editorial fix of English?

### DIFF
--- a/index.html
+++ b/index.html
@@ -3918,7 +3918,7 @@
         <p its-locale-filter-list="en" lang="en"> In letterpress printing, there were not many choices for adjustment of inter-character spacing between ruby characters. Therefore,
           depending on the number of characters in the base text and its ruby text, the choice was whether to add a certain amount of space
           before the leading ruby character and after the trailing character, or not. In the former case it had been said that for 2
-          units of inter-character spacing between each pair of ruby characters, adding 1 unit of the leading and trailing spacing would
+          units of inter-character spacing between each adjacent ruby characters, adding 1 unit of the leading and trailing spacing would
           give a balanced appearance. </p>
         <p its-locale-filter-list="ja" lang="ja">活字組版では，ルビ文字の字間調整が細かくできない場合も多く，親文字とルビ文字の字数に応じて，適宜ルビ文字の文字列の先頭及び末尾を空けない方法と空ける方法を選択して行ってきた．また，ルビ文字の文字列の先頭及び末尾を空ける場合は，ルビ文字の文字列の字間の空き量の大きさ2に対して，その先頭及び末尾の空き量を1の比率で空けると体裁がよい，といわれていた．</p>
       </aside>

--- a/index.html
+++ b/index.html
@@ -3918,7 +3918,7 @@
         <p its-locale-filter-list="en" lang="en"> In letterpress printing, there were not many choices for adjustment of inter-character spacing between ruby characters. Therefore,
           depending on the number of characters in the base text and its ruby text, the choice was whether to add a certain amount of space
           before the leading ruby character and after the trailing character, or not. In the former case it had been said that for 2
-          units of inter-character spacing between each c ruby characters, adding 1 unit of the leading and trailing spacing would
+          units of inter-character spacing between each pair of ruby characters, adding 1 unit of the leading and trailing spacing would
           give a balanced appearance. </p>
         <p its-locale-filter-list="ja" lang="ja">活字組版では，ルビ文字の字間調整が細かくできない場合も多く，親文字とルビ文字の字数に応じて，適宜ルビ文字の文字列の先頭及び末尾を空けない方法と空ける方法を選択して行ってきた．また，ルビ文字の文字列の先頭及び末尾を空ける場合は，ルビ文字の文字列の字間の空き量の大きさ2に対して，その先頭及び末尾の空き量を1の比率で空けると体裁がよい，といわれていた．</p>
       </aside>


### PR DESCRIPTION
possible fix. but I am not sure it is correct English... (updating to `2 units of inter-character spacing between each inter-character of ruby characters` is too complicated, so `2 units of spacing at every inter-character of ruby annotation` or something?)


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***

### :boom: Error: 504 Gateway Time-out :boom: ###

[PR Preview](https://github.com/tobie/pr-preview#pr-preview) failed to build. _(Last tried on Jan 6, 2022, 5:58 AM UTC)_.

<details>
<summary>More</summary>


PR Preview relies on a number of web services to run. There seems to be an issue with the following one:

:rotating_light: [HTML Diff Service](http://services.w3.org/htmldiff) - The HTML Diff Service is used to create HTML diffs of the spec changes suggested in a pull request.

:link: [Related URL](https://services.w3.org/htmldiff?doc1=https%3A%2F%2Fpr-preview.s3.amazonaws.com%2Fw3c%2Fjlreq%2Fpull%2F322%2F0d75d01.html&doc2=https%3A%2F%2Fpr-preview.s3.amazonaws.com%2Fhimorin%2Fjlreq%2Fpull%2F322.html)

```
<html><body><h1>504 Gateway Time-out</h1>
The server didn't respond in time.
</body></html>

```

_If you don't have enough information above to solve the error by yourself (or to understand to which web service the error is related to, if any), please [file an issue](https://github.com/tobie/pr-preview/issues/new?title=Error%20not%20surfaced%20properly&body=See%20w3c/jlreq%23322.)._
</details>
