### PR TITLE
Fix errors in the table

### DIFF
--- a/index.html
+++ b/index.html
@@ -22946,7 +22946,7 @@
           <td>jihaba<br/>じはば</td>
           <td>
             <p its-locale-filter-list="en" lang="en">Size of a character frame in the inline direction, generally indicated as a ratio of the size of a full-width character, as in full-width, half-width, or quarter em width. Character advance is the width of a given character in horizontal writing-mode, while it is the height in vertical writing-mode.</p>
-            <p its-locale-filter-list="ja" lang="ja">字幅が，全角の2分の1である文字の外枠．（JIS X 4051）</p>
+            <p its-locale-filter-list="ja" lang="ja">文字を配列する方向（字詰め方向）の文字の外枠の大きさ．一般に字幅の絶対値を文字サイズで除した値で示す．全角，半角，四分角など．字幅は，横組では文字の幅となるが，縦組では文字の高さとなる．</p>
           </td>
         </tr>
         <tr id="term.character-frame">

--- a/index.html
+++ b/index.html
@@ -22961,7 +22961,7 @@
         <tr id="term.character-shape">
           <td>character shape</td>
           <td>字形</td>
-          <td>jikei<br/></td>
+          <td>jikei<br/>じけい</td>
           <td>
             <p its-locale-filter-list="en" lang="en">Incarnation of a character by handwriting, printing or rendering to a computer screen. (JIS Z 8125)</p>
             <p its-locale-filter-list="ja" lang="ja">文字について，手書き，印字，画面表示などによって実際に図形として表現したもの．（JIS Z 8125）</p>
@@ -22979,7 +22979,7 @@
         <tr id="term.characters-not-ending-line">
           <td>characters not ending line</td>
           <td>行末禁則文字</td>
-          <td>gyōmatsu kinsoku moji<br/></td>
+          <td>gyōmatsu kinsoku moji<br/>ぎょうまつきんそくもじ</td>
           <td>
             <p its-locale-filter-list="en" lang="en">Any character for which "line-end prohibition rule" is invoked. (JIS Z 8125)</p>
             <p its-locale-filter-list="ja" lang="ja">行末禁則の条件に該当する文字．（JIS Z 8125）</p>
@@ -23270,7 +23270,7 @@
           <tr id="term.furigana">
             <td>furigana</td>
             <td>振り仮名</td>
-            <td>furigana<br/></td>
+            <td>furigana<br/>ふりがな</td>
             <td>
               <p its-locale-filter-list="en" lang="en">A method of ruby annotation using kana characters to indicate how to read kanji characters. This term derives from a Japanese verb "furu (to attach alongside)" and "kana", and has been used synonymously with "ruby". This document prefers to use the term "ruby".</p>
               <p its-locale-filter-list="ja" lang="ja">ルビの配置位置に，仮名を使用したもの．なお，振り仮名とは，漢字の読み方を示すために，そのわきに付ける仮名という意味で，ルビと同義的に用いられてきた．この文書では“ルビ”という用語を一貫して用いる．</p>
@@ -23279,7 +23279,7 @@
           <tr id="term.furikanji">
             <td>furikanji</td>
             <td>振り漢字</td>
-            <td>furikanji<br/>ふりがな</td>
+            <td>furikanji<br/>ふりかんじ</td>
             <td>
               <p its-locale-filter-list="en" lang="en">A method of ruby annotation using Kanji characters for ruby instead of kana characters.</p>
               <p its-locale-filter-list="ja" lang="ja">ルビの配置位置に，仮名ではなく，漢字を使用したもの．</p>


### PR DESCRIPTION
closes #334


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***

### :boom: Error: 500 Internal Server Error :boom: ###

[PR Preview](https://github.com/tobie/pr-preview#pr-preview) failed to build. _(Last tried on Jun 15, 2022, 2:43 AM UTC)_.

<details>
<summary>More</summary>


PR Preview relies on a number of web services to run. There seems to be an issue with the following one:

:rotating_light: [Spec Generator](https://www.w3.org/2015/labs/) - Spec Generator is the web service used to build specs that rely on ReSpec.

:link: [Related URL](https://labs.w3.org/spec-generator/?type=respec&url=https%3A%2F%2Fraw.githubusercontent.com%2Fw3c%2Fjlreq%2Feebdf1d8992762801af2be7faf650fb074e1ea71%2Findex.html%3FisPreview%3Dtrue)

```
Navigation timeout of 27874 ms exceeded
```

_If you don't have enough information above to solve the error by yourself (or to understand to which web service the error is related to, if any), please [file an issue](https://github.com/tobie/pr-preview/issues/new?title=Error%20not%20surfaced%20properly&body=See%20w3c/jlreq%23330.)._
</details>
