### PR TITLE
Make the Japanese and English termref consistent

### DIFF
--- a/index.html
+++ b/index.html
@@ -394,9 +394,9 @@
 <span its-locale-filter-list="ja" lang="ja">漢字及び仮名の配置の原則</span>
 </h4>
       <p its-locale-filter-list="en" lang="en">In principle, when composing a line with <a class="characterClass" href="#cl-19">ideographic (cl-19)</a>, <a class="characterClass" href="#cl-15">hiragana (cl-15)</a> and <a class="characterClass" href="#cl-16">katakana (cl-16)</a> characters no extra spacing appears between their <a href="#term.character-frame" class="termref">character frame</a>.
-        This is called  solid setting
+        This is called  <a href="#term.solid-setting" class="termref">solid setting</a>
         (see [[[#fig1_8]]]).</p>
-      <p its-locale-filter-list="ja" lang="ja"><span class="index" id="d3e509"><a class="characterClass" href="#cl-19">漢字等（cl-19）</a></span>，<a class="characterClass" href="#cl-15">平仮名（cl-15）</a>及び<a class="characterClass" href="#cl-16">片仮名（cl-16）</a>は，行に文字を配置していく際には，原則として，文字の外枠を密着させて配置する<span class="index" id="d3e519"><a href="#term.solid-setting" class="termref">ベタ組</a></span>にする（[[[#fig1_8]]]）．</p>
+      <p its-locale-filter-list="ja" lang="ja"><span class="index" id="d3e509"><a class="characterClass" href="#cl-19">漢字等（cl-19）</a></span>，<a class="characterClass" href="#cl-15">平仮名（cl-15）</a>及び<a class="characterClass" href="#cl-16">片仮名（cl-16）</a>は，行に文字を配置していく際には，原則として，文字の<a href="#term.character-frame" class="termref">外枠</a>を密着させて配置する<span class="index" id="d3e519"><a href="#term.solid-setting" class="termref">ベタ組</a></span>にする（[[[#fig1_8]]]）．</p>
       <figure id="fig1_8"> 
       <img its-locale-filter-list="en" src="images/img1_8.png" alt="Example of solid setting in horizontal writing mode." width="289" height="111">
       <img its-locale-filter-list="ja" lang="ja" src="images_ja/img1_8.png" alt="ベタ組の例 （横組の場合）" width="289" height="111">


### PR DESCRIPTION
The termref for "character frame" is not in Japanese and "ベタ組" is not in English.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***

### :boom: Error: 500 Internal Server Error :boom: ###

[PR Preview](https://github.com/tobie/pr-preview#pr-preview) failed to build. _(Last tried on Jan 29, 2024, 5:53 AM UTC)_.

<details>
<summary>More</summary>


PR Preview relies on a number of web services to run. There seems to be an issue with the following one:

:rotating_light: [Spec Generator](https://www.w3.org/2015/labs/) - Spec Generator is the web service used to build specs that rely on ReSpec.

:link: [Related URL](https://labs.w3.org/spec-generator/?type=respec&url=https%3A%2F%2Fraw.githubusercontent.com%2Fw3c%2Fjlreq%2F9e145d5a362bf8d12c9501e87e0129811c44e36c%2Findex.html%3FisPreview%3Dtrue)

```
Navigation timeout of 26519 ms exceeded
```

_If you don't have enough information above to solve the error by yourself (or to understand to which web service the error is related to, if any), please [file an issue](https://github.com/tobie/pr-preview/issues/new?title=Error%20not%20surfaced%20properly&body=See%20w3c/jlreq%23396.)._
</details>
