### PR TITLE
remove git LFS files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,0 @@
-*.indd filter=lfs diff=lfs merge=lfs -text
-*.ai filter=lfs diff=lfs merge=lfs -text


### PR DESCRIPTION
fix #454

@xfq I have already deleted the git LFS files so that .gitattributes is no longer needed