### PR TITLE
refactor respec config to avoid race condition

### DIFF
--- a/index.html
+++ b/index.html
@@ -6,8 +6,8 @@
 
 <link rel="stylesheet" href="local.css" />
 
+<script id="js-respec" class="remove" src="https://www.w3.org/Tools/respec/respec-w3c"></script>
 <script src="script.js"></script>
-<script defer id="js-respec" class="remove" src="https://www.w3.org/Tools/respec/respec-w3c"></script>
 
 <script class="remove">
       var respecConfig = {
@@ -63,7 +63,7 @@
                 {   name:       "<span lang='ja'>阿南 康宏</span> (Yasuhiro Anan), (<span lang='ja'>第１版</span> 1st edition)",
                     company:    "Microsoft" },
           ],
-		group:        "i18n",
+		group:        "wg/i18n-core",
 		//wgPublicList: "public-i18n-cjk",
 		edDraftURI: "https://w3c.github.io/jlreq/", 
  		github: "w3c/jlreq",


### PR DESCRIPTION
The `defer` attribute on the respec script can cause some race condition with spec-generator. 
That PR removes the attribute and fixes the group associated with the document.
Fix https://github.com/w3c/spec-generator/issues/396

/cc @kfranqueiro 