### PR TITLE
workflow to auto publish jpan-lreq

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,11 +1,11 @@
-name: Publish jlreq on /TR
+name: Publish jpan-lreq on /TR
 
 on:
   workflow_dispatch:
 
 jobs:
   publish-TR:
-    name: Publish jlreq
+    name: Publish jpan-lreq
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,20 @@
+name: Publish jlreq on /TR
+
+on:
+  workflow_dispatch:
+
+jobs:
+  publish-TR:
+    name: Publish jlreq
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: w3c/spec-prod@v2
+        with:
+          TOOLCHAIN: respec
+          SOURCE: jlreq/jpan/index.html
+          W3C_ECHIDNA_TOKEN: ${{ secrets.TR_TOKEN_JPAN_LREQ }}
+          W3C_WG_DECISION_URL: 
+          W3C_BUILD_OVERRIDE: |
+            specStatus: DNOTE
+            shortname: jpan-lreq


### PR DESCRIPTION
Add a GH action workflow to autopublish jpan-lreq using workflow_dispatch to control when we want to trigger the action.
The PR is missing the URL to the decision.
@r12a can you please provide the link to the decision? I already added the secret for that spec in the repo.